### PR TITLE
minor

### DIFF
--- a/docs
+++ b/docs
@@ -1,1 +1,1 @@
-server/cmwell-docs/cmwell-infodocs/
+server/cmwell-docs/cmwell-infodocs


### PR DESCRIPTION
originally was:
docs -> server/cmwell-docs/cmwell-infodocs//
now, without the extra slash:
docs -> server/cmwell-docs/cmwell-infodocs/