### PR TITLE
No need to log that index service is terminating

### DIFF
--- a/server/cmwell-batch/src/main/scala/cmwell/batch/boot/Runner.scala
+++ b/server/cmwell-batch/src/main/scala/cmwell/batch/boot/Runner.scala
@@ -92,7 +92,7 @@ object Runner extends App with LazyLogging{
   val akkaIndexer = new Indexer(uuidsTlog, updatesTlog, irwService, ftsService, indexerState)
 
   sys.addShutdownHook{
-    logger info ("stopping indexing service")
+//    logger info ("stopping indexing service")
 //    indexer.terminate
     logger info ("stopping imp service")
     impService.terminate


### PR DESCRIPTION
The index service is not terminating anymore therefor, no need to log :-)