### PR TITLE
Since /proc was not yet implemented in new UI,

### DIFF
--- a/server/cmwell-spa/data/react/css/cmwell.css
+++ b/server/cmwell-spa/data/react/css/cmwell.css
@@ -27,6 +27,16 @@ li {
     list-style-type: none;
 }
 
+.temp-proc {
+    padding: 60px;
+    color: #888;
+}
+
+.temp-proc .link {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 .not-implemented {
     color: #bdbdbd;
     font-style: italic;

--- a/server/cmwell-spa/data/react/scripts/app.jsx
+++ b/server/cmwell-spa/data/react/scripts/app.jsx
@@ -67,9 +67,26 @@ class App extends React.Component {
         return injectedInfoton && new Domain.Infoton(JSON.fromJSONL(injectedInfoton))
     }
 }
+    
+class TempProc extends React.Component {
+    componentDidMount() {
+        $('#content').show()
+        $('.spinner-container, #loading-status').fadeOut(250)
+        
+    }
+
+    render() {
+        return <div className="temp-proc">
+            <b>/proc</b> is not yet implemented in new UI. Stay tuned for updates!<br/>
+            <span className="link" onClick={()=>location.href=location.href+'?old-ui'}>Click here to view {location.pathname} in old UI</span>
+        </div>
+    }
+}
 
 ReactDOM.render((
   <Router history={browserHistory}>
+    <Route path="/proc" component={TempProc}/>
+    <Route path="/proc/:page" component={TempProc}/>
     <Route path="*" component={App}/>
   </Router>
 ), document.getElementById('content'))


### PR DESCRIPTION
redirecting users to use the old UI for each /proc/* URL,
rather than having the browser stuck.