### PR TITLE
setting `halfClose` flag in TCP out going connection to false. seems …

### DIFF
--- a/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/ZookeeperChecker.scala
+++ b/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/ZookeeperChecker.scala
@@ -70,7 +70,7 @@ object ZookeeperChecker extends Checker with LazyLogging {
 
   private def singleTcp(host: String, port: Int, request: String): Future[String] = {
     val (killSwitch, futureByteString) = Source.single(ByteString(request))
-      .via(Tcp().outgoingConnection(new InetSocketAddress(host, port), None, Nil, true, 5.seconds, 5.seconds))
+      .via(Tcp().outgoingConnection(new InetSocketAddress(host, port), None, Nil, false, 5.seconds, 5.seconds))
       .viaMat(KillSwitches.single)(Keep.right)
       .toMat(Sink.head)(Keep.both)
       .run()


### PR DESCRIPTION
…like connection is closed anyway, but since we see too many connections to zookeeper, it is better to be on the safe side, and get the connection to close eagerly on client side