### PR TITLE
revert zookeeper tcp back to not close connection

### DIFF
--- a/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/ZookeeperChecker.scala
+++ b/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/ZookeeperChecker.scala
@@ -70,7 +70,7 @@ object ZookeeperChecker extends Checker with LazyLogging {
 
   private def singleTcp(host: String, port: Int, request: String): Future[String] = {
     val (killSwitch, futureByteString) = Source.single(ByteString(request))
-      .via(Tcp().outgoingConnection(new InetSocketAddress(host, port), None, Nil, false, 5.seconds, 5.seconds))
+      .via(Tcp().outgoingConnection(new InetSocketAddress(host, port), None, Nil, true, 5.seconds, 5.seconds))
       .viaMat(KillSwitches.single)(Keep.right)
       .toMat(Sink.head)(Keep.both)
       .run()


### PR DESCRIPTION
without it the client closes the connection before the server's response