### PR TITLE
tlog tool assembly failed. fixed it by adding merge strategy in build.sbt

### DIFF
--- a/server/cmwell-tlog/build.sbt
+++ b/server/cmwell-tlog/build.sbt
@@ -39,6 +39,7 @@ assemblyJarName in assembly := {
 
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", "cxf", "bus-extensions.txt") => MergeStrategy.concat
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)


### PR DESCRIPTION
Got this error before:
```text
[error] (tlog/*:assembly) deduplicate: different file contents found in the following:
[error] /home/gilad/.coursier/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.0.44.Final/netty-codec-4.0.44.Final.jar:META-INF/io.netty.versions.properties
[error] /home/gilad/.coursier/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.0.44.Final/netty-handler-4.0.44.Final.jar:META-INF/io.netty.versions.properties
[error] /home/gilad/.coursier/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.0.44.Final/netty-buffer-4.0.44.Final.jar:META-INF/io.netty.versions.properties
[error] /home/gilad/.coursier/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.0.44.Final/netty-common-4.0.44.Final.jar:META-INF/io.netty.versions.properties
[error] /home/gilad/.coursier/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.0.44.Final/netty-transport-4.0.44.Final.jar:META-INF/io.netty.versions.properties
```