### PR TITLE
Check services state each 30 seconds

### DIFF
--- a/server/cmwell-grid/src/main/scala/k/grid/service/ServiceCoordinator.scala
+++ b/server/cmwell-grid/src/main/scala/k/grid/service/ServiceCoordinator.scala
@@ -45,7 +45,7 @@ class ServiceCoordinator extends Actor with LazyLogging {
 
   @throws[Exception](classOf[Exception])
   override def preStart(): Unit = {
-    Grid.system.scheduler.schedule(0.seconds, 10.seconds, self, SendRegistrations)
+    Grid.system.scheduler.schedule(0.seconds, 30.seconds, self, SendRegistrations)
   }
 
   override def receive: Receive = {


### PR DESCRIPTION
The previous duration was 10 seconds. This caused an issue that the services wasn't fully up before the next check cycle and the ServiceCoordinator spawned another service by mistake.