### PR TITLE
sparql-triggered-processor paths are not always unique

### DIFF
--- a/server/cmwell-data-tools-app/src/main/resources/logback.xml
+++ b/server/cmwell-data-tools-app/src/main/resources/logback.xml
@@ -39,7 +39,7 @@
             <maxIndex>21</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
+            <maxFileSize>200MB</maxFileSize>
         </triggeringPolicy>
     </appender>
 
@@ -55,7 +55,7 @@
             <maxIndex>21</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
+            <maxFileSize>200MB</maxFileSize>
         </triggeringPolicy>
     </appender>
 
@@ -75,14 +75,14 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>logs/bad-data.log.%i</fileNamePattern>
-            <maxIndex>100</maxIndex>
+            <maxIndex>21</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10000000</maxFileSize>
+            <maxFileSize>200MB</maxFileSize>
         </triggeringPolicy>
     </appender>
 
-    <logger name="akka" level="INFO" additivity="false">
+    <logger name="akka" level="DEBUG" additivity="false">
         <appender-ref ref="AkkaFile" />
     </logger>
 

--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/sparql/SparqlTriggeredProcessor.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/sparql/SparqlTriggeredProcessor.scala
@@ -219,7 +219,7 @@ class SparqlTriggeredProcessor(config: Config,
     val processedConfig = Await.result(preProcessConfig(config), 3.minutes)
 
     val sensorSource = createSensorSource(processedConfig)
-      .groupedWithin(config.sensors.size, 10.seconds)
+      .groupedWithin(10000, 10.seconds)
       .statefulMapConcat{ () =>
         // stores last received tokens from sensors
         sensorData => {


### PR DESCRIPTION
paths that are detected from sensors are now filtered if they are not
distinct in the specified timed window.

changed data-tools executable log files size and akka log level.