### PR TITLE
optimized file infoton serialization and got rid of wrong warning log

### DIFF
--- a/server/cmwell-domain/src/main/scala/cmwell/domain/InfotonSerializer.scala
+++ b/server/cmwell-domain/src/main/scala/cmwell/domain/InfotonSerializer.scala
@@ -170,7 +170,7 @@ object InfotonSerializer extends LazyLogging {
             val content = {
               if (mimeType eq null) None
               else {
-                val content = fileContentBuilder//.result()
+                val content = fileContentBuilder
 
                 if(fileContentBuildPosition != fileContentLength)
                   logger.warn(s"content has different length than expected. expected: [$fileContentLength], actual: [$fileContentBuildPosition/${content.length}] for uuid [$uuidHint]")

--- a/server/cmwell-it/src/it/scala/cmwell/it/APIValidationTests.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/APIValidationTests.scala
@@ -105,7 +105,11 @@ class APIValidationTests extends FunSpec with Matchers with Inspectors with Help
       }
 
       it("should get the data when trying to get it") {
-        cmwell.util.string.Hash.sha1(Await.result(Http.get(path), requestTimeout).body._2) should be(checksum)
+        Http.get(path).map{ res =>
+          withClue(res) {
+            cmwell.util.string.Hash.sha1(res.payload) should be(checksum)
+          }
+        }
       }
     }
 


### PR DESCRIPTION
We've seen the following warning in logs:
```
WARN content has different length than expected. expected: [...], actual: [...] for uuid [...]
```
But content was valid. also, `ArrayBuilder` does redundant upcasting and downcasting(via `match`) for value types. we can do better, using a regular array directly.

Also added some minor boy-scouting changes while at it.