### PR TITLE
remove ?old-ui query parameter from url, if exists

### DIFF
--- a/server/cmwell-spa/data/scripts/controllers.js
+++ b/server/cmwell-spa/data/scripts/controllers.js
@@ -625,7 +625,7 @@ angular.module('cmwellAngApp.controllers', [])
     }
 
     
-    if(location.href.indexOf('?old-ui')>-1)
+    if(location.href.indexOf('?old-ui') > -1)
         setTimeout(function(){ $('<a class="not-displayed" href="'+location.href.replace('?old-ui','')+'">').appendTo('.header').click(); }, 100);
 
 

--- a/server/cmwell-spa/data/scripts/controllers.js
+++ b/server/cmwell-spa/data/scripts/controllers.js
@@ -624,6 +624,9 @@ angular.module('cmwellAngApp.controllers', [])
         });
     }
 
+    
+    if(location.href.indexOf('?old-ui')>-1)
+        setTimeout(function(){ $('<a class="not-displayed" href="'+location.href.replace('?old-ui','')+'">').appendTo('.header').click(); }, 100);
 
 
     showMsgOfTheDayIfNeeded();


### PR DESCRIPTION
- which fixes Types navigation that broke becuase of it, as well as other features, such as Format drop-down