### PR TITLE
Sparql triggered processor dashboard not display data

### DIFF
--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/downloader/consumer/Downloader.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/downloader/consumer/Downloader.scala
@@ -703,9 +703,6 @@ class Downloader(baseUrl: String,
     import akka.pattern._
     val prefetchBufferSize = 3000000
 
-    // contains http response data of current chunk
-    val buffer = new java.util.concurrent.ArrayBlockingQueue[Option[TokenAndTsv]](prefetchBufferSize)
-
     val initTokenFuture = token match {
       case Some(t) => Future.successful(t)
       case None => Downloader.getToken(

--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/sparql/SparqlTriggeredProcessor.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/sparql/SparqlTriggeredProcessor.scala
@@ -84,7 +84,7 @@ class SparqlTriggeredProcessor(config: Config,
           .map { case (data, _) => data }
           .toMat(DownloaderStatsSink(
             format = "ntriples",
-            label = Some(label.map(l => s"$l-$id").getOrElse(id)),
+            label = Some(id),
             reporter = Some(tokenReporter)
           ))(Keep.right)
       )
@@ -167,7 +167,7 @@ class SparqlTriggeredProcessor(config: Config,
                 isBulk  = isBulk,
                 token   = token,
                 updateFreq  = Some(config.updateFreq),
-                label = Some(label.map(l => s"$l-${sensor.name}").getOrElse(sensor.name)))
+                label = Some(sensor.name))
                 .map {
                   case (token, tsv) =>
                     val path = tsv.path
@@ -190,7 +190,7 @@ class SparqlTriggeredProcessor(config: Config,
               sparqlQuery = sensor.sparqlToRoot.get,
               spQueryParamsBuilder = (p: Seq[String]) => "sp.pid=" + p.head.substring(p.head.lastIndexOf('-') + 1),
               format = Some("tsv"),
-              label = Some(label.map(l => s"$l-${sensor.name}").getOrElse(sensor.name)),
+              label = Some(sensor.name),
               source = source.map{ case (path, context) =>
                 context.foreach(c => logger.debug("sensor [{}] is trying to get root infoton of {}", c.name , path.utf8String))
                 path -> context}
@@ -251,7 +251,7 @@ class SparqlTriggeredProcessor(config: Config,
 
     // execute sparql queries on populated paths
     addStatsToSource (
-      id = SparqlTriggeredProcessor.sparqlMaterializerLabel,
+      id = label.map(_ + "-").getOrElse("") + SparqlTriggeredProcessor.sparqlMaterializerLabel,
       source = SparqlProcessor.createSparqlSourceFromPaths(
           baseUrl = baseUrl,
           sparqlQuery = processedConfig.sparqlMaterializer,

--- a/server/cmwell-dc/src/pack/logback.xml
+++ b/server/cmwell-dc/src/pack/logback.xml
@@ -189,7 +189,7 @@
         <appender-ref ref="ASYNC_AKKA_FILE" />
     </logger>
 
-    <logger name="cmwell.tools.data.sparql" additivity="false">
+    <logger name="cmwell.tools.data" additivity="false">
         <appender-ref ref="ASYNC_AGENTS_FILE"/>
     </logger>
 

--- a/server/cmwell-sparql-agent/src/main/scala/cmwell/tools/data/sparql/SparqlProcessorManager.scala
+++ b/server/cmwell-sparql-agent/src/main/scala/cmwell/tools/data/sparql/SparqlProcessorManager.scala
@@ -154,7 +154,14 @@ class SparqlProcessorManager extends Actor with LazyLogging {
         getYamlConfigs().map(AnalyzeReceivedConfig.apply) pipeTo self
 
       case AnalyzeReceivedConfig(received) =>
-        handleSensors(received)
+        handleSensors {
+          received.map { case (path, config) =>
+            val configName = Paths.get(path.utf8String).getFileName
+            val sensors = config.sensors.map(sensor => sensor.copy(name = s"$configName-${sensor.name}"))
+            path -> config.copy(sensors = sensors)
+          }
+        }
+//        handleSensors(received)
 
       case StartJob(registered, path, config) if registered =>
         val job = startJob(path, config)
@@ -288,7 +295,6 @@ class SparqlProcessorManager extends Actor with LazyLogging {
     }
 
     def generateActiveTables() = activeJobs.map { case (path, job) =>
-      val sensorNames = job.config.sensors.map(_.name)
       val title = Seq(s"""<span style="color:green"> **Active** </span> ${path.utf8String}""")
       val header = Seq("sensor", "point-in-time", "received-infotons", "infoton-rate", "last-update")
 
@@ -302,6 +308,7 @@ class SparqlProcessorManager extends Actor with LazyLogging {
         stats <- statsFuture
         storedTokens <- storedTokensFuture
       } yield {
+        val sensorNames = job.config.sensors.map(_.name)
         val pathsWithoutSavedToken = sensorNames.toSet diff storedTokens.keySet
         val allSensorsWithTokens = storedTokens ++ pathsWithoutSavedToken.map(_ -> "")
 
@@ -321,7 +328,8 @@ class SparqlProcessorManager extends Actor with LazyLogging {
           row
         }
 
-        val sparqlMaterializerStats = stats.get(SparqlTriggeredProcessor.sparqlMaterializerLabel).map { s =>
+        val configName = Paths.get(path.utf8String).getFileName
+        val sparqlMaterializerStats = stats.get(s"$configName-${SparqlTriggeredProcessor.sparqlMaterializerLabel}").map { s =>
           val totalRunTime = DurationFormatUtils.formatDurationWords(s.runningTime, true, true)
           s"""Materialized <span style="color:green"> **${s.receivedInfotons}** </span> infotons [$totalRunTime]""".stripMargin
         }.getOrElse("")


### PR DESCRIPTION
Dashboard of sparql-triggered-processor now displays data correctly.
The problem was mismatching labels of sparql-triggered-processor components which were reported to the `InfotonReporter` actor.