### PR TITLE
removed unused config param

### DIFF
--- a/server/cmwell-bg/src/main/resources/application.conf
+++ b/server/cmwell-bg/src/main/resources/application.conf
@@ -43,5 +43,6 @@ akka {
   #akka is configured to log in DEBUG level. The actual level is determined by logback
   loglevel = "DEBUG"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
-  log-config-on-start = off
 }
+
+cmwell.grid.akka.log-config-on-start = off

--- a/server/cmwell-bg/src/main/scala/cmwell/bg/CMWellBGActor.scala
+++ b/server/cmwell-bg/src/main/scala/cmwell/bg/CMWellBGActor.scala
@@ -77,6 +77,7 @@ class CMWellBGActor(partition:Int, config:Config, irwService:IRWService, ftsServ
   override def postStop(): Unit = {
       logger info s"CMWellBGActor-$partition stopping"
     esReporterOpt.foreach(_.close())
+    stopAll
     super.postStop()
   }
 

--- a/server/cmwell-bg/src/main/scala/cmwell/bg/ImpStream.scala
+++ b/server/cmwell-bg/src/main/scala/cmwell/bg/ImpStream.scala
@@ -76,7 +76,6 @@ class ImpStream(partition:Int, config:Config, irwService:IRWService, zStore: ZSt
   val bootStrapServers = config.getString("cmwell.bg.kafka.bootstrap.servers")
   val persistCommandsTopic = config.getString("cmwell.bg.persist.commands.topic")
   val indexCommandsTopic = config.getString("cmwell.bg.index.commands.topic")
-  val latestIndexAliasName = config.getString("cmwell.bg.latestIndexAliasName")
   val maxInfotonWeightToIncludeInCommand = config.getInt("cmwell.bg.maxInfotonWeightToIncludeInCommand")
   val defaultDC = config.getString("cmwell.dataCenter.id")
   val esActionsBulkSize = config.getInt("cmwell.bg.esActionsBulkSize") // in bytes

--- a/server/cmwell-bg/src/test/resources/application.conf
+++ b/server/cmwell-bg/src/test/resources/application.conf
@@ -6,7 +6,6 @@ cmwell.bg.index.commands.topic=index_topic
 cmwell.bg.index.commands.partition=0
 cmwell.bg.num.of.cassandra.nodes=1
 cmwell.bg.allIndicesAliasName=cm_well_all
-cmwell.bg.latestIndexAliasName=cm_well_latest
 cmwell.bg.indexNamePrefix=cm_well_
 cmwell.bg.maxDocsPerShard=10
 cmwell.bg.maintainIndicesInterval=2

--- a/server/cmwell-bg/src/test/scala/cmwell/bg/test/BGMergerSpec.scala
+++ b/server/cmwell-bg/src/test/scala/cmwell/bg/test/BGMergerSpec.scala
@@ -223,4 +223,60 @@ class BGMergerSpec extends FlatSpec with Matchers with OptionValues {
 
     merged shouldBe empty
   }
+
+  it should "merge null update commands with no base correctly" in {
+    val now = DateTime.now
+    val infoton1 = ObjectInfoton(
+      "/bg-test-merge/infonull1",
+      "dc1",
+      None,
+      now,
+      None
+    )
+    val infoton2 = ObjectInfoton(
+      "/bg-test-merge/infonull1",
+      "dc1",
+      None,
+      now.plusMillis(20),
+      None
+    )
+    val writeCommand1 = WriteCommand(infoton1)
+    val writeCommand2 = WriteCommand(infoton2)
+    val merged = merger.merge(None, Seq(writeCommand1, writeCommand2))
+
+    merged.merged shouldEqual(Some(infoton2))
+
+  }
+
+  it should "merge null update commands with different base correctly" in {
+    val now = DateTime.now
+    val baseInfoton = ObjectInfoton(
+      "/bg-test-merge/infonull1",
+      "dc1",
+      None,
+      now,
+      None
+    )
+    val infoton1 = ObjectInfoton(
+      "/bg-test-merge/infonull1",
+      "dc1",
+      None,
+      now.minusMillis(161),
+      None
+    )
+    val infoton2 = ObjectInfoton(
+      "/bg-test-merge/infonull1",
+      "dc1",
+      None,
+      now.plusMillis(53),
+      None
+    )
+    val writeCommand1 = WriteCommand(infoton1)
+    val writeCommand2 = WriteCommand(infoton2)
+    val merged = merger.merge(Some(baseInfoton), Seq(writeCommand2, writeCommand1))
+
+    merged.merged shouldBe empty
+
+  }
+
 }

--- a/server/cmwell-grid/src/main/scala/k/grid/service/ServiceCoordinator.scala
+++ b/server/cmwell-grid/src/main/scala/k/grid/service/ServiceCoordinator.scala
@@ -45,7 +45,7 @@ class ServiceCoordinator extends Actor with LazyLogging {
 
   @throws[Exception](classOf[Exception])
   override def preStart(): Unit = {
-    Grid.system.scheduler.schedule(0.seconds, 10.seconds, self, SendRegistrations)
+    Grid.system.scheduler.schedule(0.seconds, 30.seconds, self, SendRegistrations)
   }
 
   override def receive: Receive = {


### PR DESCRIPTION
turned off akka init log in BG process
stop streams when BGActor stops
changed monitoring interval in service coordinator (Grid) from 10 to 30 seconds