### PR TITLE
Bug fix in consumer tool actor and other minor changes

### DIFF
--- a/server/cmwell-data-tools-app/src/main/scala/cmwell/tools/data/downloader/ConsumerMain.scala
+++ b/server/cmwell-data-tools-app/src/main/scala/cmwell/tools/data/downloader/ConsumerMain.scala
@@ -45,14 +45,12 @@ object ConsumerMain extends App with InstrumentedBuilder{
     val params = opt[String]("params", descr = "params string in cm-well", default = Some(""))
     val qp = opt[String]("qp", descr = "query params in cm-well", default = Some(""))
     val recursive = opt[Boolean]("recursive", short = 'r', descr = "flag to get download data recursively", default = Some(false))
-    val length = opt[Int]("length", short = 'l', descr = "max number of records to download (i.e., 1, 100)", default = None)
     val format = opt[String]("format", descr = "desired record format (i.e., json, jsonld, jsonldq, n3, ntriples, nquads, trig, rdfxml)", default = Some("trig"))
     val state   = opt[String]("state", short = 's',  descr = "position state file")
     val follow = opt[String]("follow", short = 'f', descr = "continue consumption data after given update frequency (i.e., 5.seconds, 10.minutes etc.)")
     val bulk = opt[Boolean]("bulk", default = Some(false), descr = "use bulk consumer mode in download")
     val numConnections = opt[Int]("num-connections", descr = "number of http connections to open")
-
-    mutuallyExclusive(bulk, length)
+    val indexTime = opt[Long]("index-time", descr = "index-time lower bound", default = Some(0))
 
     verify()
   }
@@ -83,7 +81,7 @@ object ConsumerMain extends App with InstrumentedBuilder{
     recursive = Opts.recursive(),
     format = Opts.format(),
     isBulk = Opts.bulk(),
-    length = Opts.length.toOption
+    indexTime = Opts.indexTime()
   )
 
   // check if input contains a valid state file which contains initial token
@@ -108,7 +106,7 @@ object ConsumerMain extends App with InstrumentedBuilder{
     FiniteDuration(d.length, d.unit)
   }
 
-  val result = downloader.createTsvSource(tokenToQuery, updateFreq)
+  val result = downloader.createTsvSource(tokenToQuery, updateFreq).async
     .map { case (token, tsv) => token -> tsv.uuid }
     .via(downloader.downloadDataFromUuids())
     .map {case (token, data) =>

--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/downloader/consumer/japi/DownloaderUtils.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/downloader/consumer/japi/DownloaderUtils.scala
@@ -200,7 +200,6 @@ object DownloaderUtils {
       params    = if (params == null) "" else params,
       qp        = if (qp == null) "" else qp,
       format    = if (format == null) "trig" else format,
-      length    = Option(lengthHint),
       recursive = recursive
     )
 

--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/HeaderOps.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/HeaderOps.scala
@@ -22,6 +22,7 @@ object HeaderOps {
   val CMWELL_HOSTNAME = "X-CMWELL-Hostname"
   val CMWELL_POSITION = "X-CM-WELL-POSITION"
   val CMWELL_N        = "X-CM-WELL-N"
+  val CMWELL_RT       = "X-CMWELL-RT"
 
   def getHeader(name: String)(headers: Seq[HttpHeader]) = headers.find(_.name == name)
 
@@ -33,8 +34,10 @@ object HeaderOps {
   val getHostname    = getHeader(CMWELL_HOSTNAME) _
   val getPosition    = getHeader(CMWELL_POSITION) _
   val getNumInfotons = getHeader(CMWELL_N) _
+  val getResponseTime = getHeader(CMWELL_RT) _
 
   val getHostnameValue    = getHostname andThen getHeaderValue
   val getPositionValue    = getPosition andThen getHeaderValue
   val getNumInfotonsValue = getNumInfotons andThen getHeaderValue
+  val getResponseTimeValue = getResponseTime andThen getHeaderValue
 }

--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/Retry.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/Retry.scala
@@ -149,8 +149,6 @@ object Retry extends DataToolsLogging with DataToolsConfig{
         }
 
       case State(data, _, None, count) =>
-        logger.warn(s"$labelValue error: could not send http request, data=${stringifyData(data)}")
-
         count match {
           case Some(c) if c > 0 =>
             logger.warn(s"$labelValue error: could not send http request, counter=$c will retry again in $delay data=${stringifyData(data)}")


### PR DESCRIPTION
- Fix bug in BufferFillerActor in consumer tool. In case of HTTP failure, it will consume the next token after the current retry.
- Remove length argument from consumer tool.
- Add CM-WELL-RT header value to consumer tool logs.
- Change calls to `_out` to use `HTTP.toStrict` in order to set a limit on processing time of HTTP response.
- Add label support in data-tools http connection pool factory. 