### PR TITLE
UI displayName bugfix

### DIFF
--- a/server/cmwell-spa/data/main/scripts/domain.jsx
+++ b/server/cmwell-spa/data/main/scripts/domain.jsx
@@ -39,7 +39,11 @@ class Infoton {
             }
         }
 
-        return _(dnFuncsAndVals).chain().map(apply).find(_.identity).value().value
+        let result = _(dnFuncsAndVals).chain().map(apply).find(_.identity).value()
+        if(result)
+            return result.value
+        else
+            console.warn(`[DisplayName] Infoton ${this.path} of type ${typerdf.value} has none of the fields [${dnFuncsAndVals.join`,`}]`)
     }
 }
 


### PR DESCRIPTION
when a displayName is defined for a certain type.rdf but the displayed Infoton of that type has no such field. Rather than showing  an error msg, fallback to path, and add console warning.
Fixes #91