### PR TITLE
Consume and Bulk Consume: hanlde a case with lots of infotons with the same index time

### DIFF
--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -1130,7 +1130,7 @@ callback=< [URL] >
             case SearchThinResults(total, _, _, results, _) if results.nonEmpty => {
 
               val idxT = results.maxBy(_.indexTime).indexTime //infotons.maxBy(_.indexTime.getOrElse(0L)).indexTime.getOrElse(0L)
-              require(idxT > 0, "all infotons in iteration must have a valid indexTime defined")
+              require(idxT >= 0, "all infotons in iteration must have a valid indexTime defined")
 
               // last chunk
               if (results.length >= total)

--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -1130,7 +1130,6 @@ callback=< [URL] >
             case SearchThinResults(total, _, _, results, _) if results.nonEmpty => {
 
               val idxT = results.maxBy(_.indexTime).indexTime //infotons.maxBy(_.indexTime.getOrElse(0L)).indexTime.getOrElse(0L)
-              require(idxT >= 0, "all infotons in iteration must have a valid indexTime defined")
 
               // last chunk
               if (results.length >= total)

--- a/server/cmwell-ws/app/controllers/BulkScrollHandler.scala
+++ b/server/cmwell-ws/app/controllers/BulkScrollHandler.scala
@@ -111,7 +111,9 @@ class BulkScrollHandler @Inject()(crudServiceFS: CRUDServiceFS,
           withDeleted = d
         ).map {
         case SearchThinResults(_, _, _, results, _) =>
-          results.headOption.fold(now)(_.indexTime)
+          //In case that there are more than the initial seed infotons (=1000) with the same index time the "from" will be equal to the "to"
+          //This will fail the FieldFilter requirements (see getFieldFilterSeq) and thus approx. 1 second is added to the "from" as the new "to"
+          results.headOption.fold(now)(i => math.max(i.indexTime,from+1729L)) //https://en.wikipedia.org/wiki/1729_(number)
       }
     }
 


### PR DESCRIPTION
1. Consume can now handle infotons with indexTime=0
2. BulkConsume can now handle more than 1000 infotons that have indexTime equals to the "from" section in the token