### PR TITLE
Allow adding qp to virtual dc infotons

### DIFF
--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
@@ -1035,7 +1035,7 @@ class FTSServiceES private(classPathConfigFile: String, waitForGreen: Boolean)
     }
   }
 
-  def getLastIndexTimeFor(dc: String, partition: String = defaultPartition)
+  def getLastIndexTimeFor(dc: String, partition: String = defaultPartition, fieldFilters: Option[FieldFilter])
                          (implicit executionContext: ExecutionContext) : Future[Option[Long]] = {
 
     val request = client
@@ -1050,9 +1050,9 @@ class FTSServiceES private(classPathConfigFile: String, waitForGreen: Boolean)
       None,
       Some(MultiFieldFilter(Must, Seq(
         SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
-        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")), //NO META
-        SingleFieldFilter(Must, GreaterThan, "system.lastModified", Some("1970"))
-      ))),
+        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
+      ) ++ fieldFilters
+      )),
       None
     )
 

--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
@@ -1045,14 +1045,14 @@ class FTSServiceES private(classPathConfigFile: String, waitForGreen: Boolean)
       .setSize(1)
       .addSort("system.indexTime", SortOrder.DESC)
 
+    val filtersSeq:List[FieldFilter] = List(
+      SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
+      SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
+    )
     applyFiltersToRequest(
       request,
       None,
-      Some(MultiFieldFilter(Must, Seq(
-        SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
-        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
-      ) ++ fieldFilters
-      )),
+      Some(MultiFieldFilter(Must, fieldFilters.fold(filtersSeq)(filtersSeq.::))),
       None
     )
 

--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceNew.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceNew.scala
@@ -1001,14 +1001,14 @@ class FTSServiceNew(config: Config, esClasspathYaml: String) extends FTSServiceO
       .setSize(1)
       .addSort("system.indexTime", SortOrder.DESC)
 
+    val filtersSeq:List[FieldFilter] = List(
+      SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
+      SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
+    )
     applyFiltersToRequest(
       request,
       None,
-      Some(MultiFieldFilter(Must, Seq(
-        SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
-        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
-      ) ++ fieldFilters
-      )),
+      Some(MultiFieldFilter(Must, fieldFilters.fold(filtersSeq)(filtersSeq.::))),
       None
     )
 

--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceNew.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceNew.scala
@@ -991,7 +991,7 @@ class FTSServiceNew(config: Config, esClasspathYaml: String) extends FTSServiceO
     }
   }
 
-  def getLastIndexTimeFor(dc: String, partition: String)
+  def getLastIndexTimeFor(dc: String, partition: String, fieldFilters: Option[FieldFilter])
                          (implicit executionContext:ExecutionContext): Future[Option[Long]] = {
 
     val request = client
@@ -1006,9 +1006,9 @@ class FTSServiceNew(config: Config, esClasspathYaml: String) extends FTSServiceO
       None,
       Some(MultiFieldFilter(Must, Seq(
         SingleFieldFilter(Must, Equals, "system.dc", Some(dc)),                                 //ONLY DC
-        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")), //NO META
-        SingleFieldFilter(Must, GreaterThan, "system.lastModified", Some("1970"))
-      ))),
+        SingleFieldFilter(MustNot, Contains, "system.parent.parent_hierarchy", Some("/meta/")) //NO META
+      ) ++ fieldFilters
+      )),
       None
     )
 

--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceOps.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceOps.scala
@@ -116,7 +116,7 @@ trait FTSServiceOps {
                  debugInfo: Boolean = false, timeout : Option[Duration] = None)
                 (implicit executionContext:ExecutionContext): Future[FTSThinSearchResponse]
 
-  def getLastIndexTimeFor(dc: String, partition: String = defaultPartition)
+  def getLastIndexTimeFor(dc: String, partition: String = defaultPartition, fieldFilters: Option[FieldFilter])
                          (implicit executionContext:ExecutionContext): Future[Option[Long]]
 
   def startSuperScroll(pathFilter: Option[PathFilter], fieldsFilter: Option[FieldFilter], datesFilter: Option[DatesFilter],

--- a/server/cmwell-ws/app/actions/ActiveInfotonGenerator.scala
+++ b/server/cmwell-ws/app/actions/ActiveInfotonGenerator.scala
@@ -34,8 +34,10 @@ import logic.CRUDServiceFS
 import org.joda.time._
 import trafficshaping.TrafficMonitoring
 import wsutil._
-
 import javax.inject._
+
+import cmwell.fts.FieldFilter
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -589,7 +591,7 @@ ${lines.mkString("\n")}
   import scala.language.implicitConversions
 
 
-  def generateInfoton(host: String, path: String, md: DateTime = new DateTime(), length: Int = 0, offset: Int = 0, isRoot : Boolean = false, nbg: Boolean = false): Future[Option[VirtualInfoton]] = {
+  def generateInfoton(host: String, path: String, md: DateTime = new DateTime(), length: Int = 0, offset: Int = 0, isRoot : Boolean = false, nbg: Boolean = false, fieldFilters: Option[FieldFilter]): Future[Option[VirtualInfoton]] = {
 
     implicit def iOptAsFuture(iOpt: Option[VirtualInfoton]): Future[Option[VirtualInfoton]] = Future.successful(iOpt)
 
@@ -604,7 +606,7 @@ ${lines.mkString("\n")}
       case "/proc" => {val pk = procKids; Some(VirtualInfoton(CompoundInfoton(path, dc, None, md,None,pk.slice(offset,offset+length),offset,min(pk.drop(offset).size,length),pk.size)))}
       case "/proc/node" => Some(VirtualInfoton(ObjectInfoton(path, dc, None, md,nodeValFields)))
       case "/proc/dc" => compoundDC
-      case p if p.startsWith("/proc/dc/") => crudServiceFS.getLastIndexTimeFor(p.drop("/proc/dc/".length))
+      case p if p.startsWith("/proc/dc/") => crudServiceFS.getLastIndexTimeFor(p.drop("/proc/dc/".length), nbg, fieldFilters)
       case "/proc/fields" => crudServiceFS.getESFieldsVInfoton(nbg).map(Some.apply)
       case "/proc/health" => Some(VirtualInfoton(ObjectInfoton(path, dc, None, md, generateHealthFields)))
       case "/proc/health.md" => Some(VirtualInfoton(FileInfoton(path, dc, None, content = Some(FileContent(generateHealthMarkdown.getBytes, "text/x-markdown")))))

--- a/server/cmwell-ws/app/logic/CRUDServiceFS.scala
+++ b/server/cmwell-ws/app/logic/CRUDServiceFS.scala
@@ -41,7 +41,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.producer.{Callback, KafkaProducer, ProducerRecord, RecordMetadata}
 import org.elasticsearch.action.bulk.BulkResponse
 import org.joda.time.{DateTime, DateTimeZone}
-import wsutil.FormatterManager
+import wsutil.{FormatterManager, RawFieldFilter}
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -632,13 +632,13 @@ class CRUDServiceFS @Inject()(tbg: NbgToggler)(implicit ec: ExecutionContext, sy
     }
   }
 
-  def getLastIndexTimeFor(dc: String = Settings.dataCenter, nbg: Boolean = newBG): Future[Option[VirtualInfoton]] = {
+  def getLastIndexTimeFor(dc: String = Settings.dataCenter, nbg: Boolean, fieldFilters: Option[FieldFilter]): Future[Option[VirtualInfoton]] = {
 
     def mkVirtualInfoton(indexTime: Long): VirtualInfoton =
       VirtualInfoton(ObjectInfoton(s"/proc/dc/$dc", Settings.dataCenter, None,
         Map("lastIdxT" -> Set[FieldValue](FLong(indexTime)),
           "dc" -> Set[FieldValue](FString(dc)))))
-    ftsService(nbg).getLastIndexTimeFor(dc).map(lOpt => Some(mkVirtualInfoton(lOpt.getOrElse(0L))))
+    ftsService(nbg).getLastIndexTimeFor(dc, fieldFilters =  fieldFilters).map(lOpt => Some(mkVirtualInfoton(lOpt.getOrElse(0L))))
   }
 
   def getESFieldsVInfoton(nbg: Boolean = newBG): Future[VirtualInfoton] = {


### PR DESCRIPTION
Adding &qp=... to /proc/dc/someId is now allowed.

This is part of adding dc-sync to ability to sync only part of the data. The virtual infoton is used by the monitor and also in dc itself to check what is the last infoton of the desired query.