### PR TITLE
Using a custom Exception in case when UI is not available.

### DIFF
--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -2197,7 +2197,7 @@ class CachedSpa @Inject()(crudServiceFS: CRUDServiceFS)(implicit ec: ExecutionCo
       case FullBox(FileInfoton(_, _, _, _, _, Some(c),_)) => new String(c.data.get, "UTF-8")
       case somethingElse => {
         logger.error("got something else: " + somethingElse)
-        ???
+        throw new SpaMissingException("SPA Content is currently unreachable")
       }
     }
   }
@@ -2212,3 +2212,5 @@ class CachedSpa @Inject()(crudServiceFS: CRUDServiceFS)(implicit ec: ExecutionCo
       else newObgCache.getAndUpdateIfNeeded
     }
 }
+
+class SpaMissingException(msg :String) extends Exception(msg)

--- a/server/cmwell-ws/app/wsutil/package.scala
+++ b/server/cmwell-ws/app/wsutil/package.scala
@@ -32,6 +32,7 @@ import com.typesafe.scalalogging.LazyLogging
 import ld.exceptions.BadFieldTypeException
 import logic.CRUDServiceFS
 import cmwell.util.concurrent.SimpleScheduler
+import controllers.SpaMissingException
 import ld.cmw.PassiveFieldTypesCache
 import play.api.libs.json.Json
 import play.api.mvc.Results._
@@ -663,6 +664,7 @@ package object wsutil extends LazyLogging {
   def exceptionToResponse(throwable: Throwable): Result = {
     val (status,eHandler): (Status,Throwable => String) = throwable match {
       case _: TimeoutException => ServiceUnavailable -> {_.getMessage}
+      case _: SpaMissingException => ServiceUnavailable -> {_.getMessage}
       case _: UnretrievableIdentifierException => UnprocessableEntity -> {_.getMessage}
       case _: PrefixAmbiguityException => UnprocessableEntity -> {_.getMessage}
       case _: security.UnauthorizedException => Forbidden -> {_.getMessage}


### PR DESCRIPTION
This way an upgrade can be successful even if for some reason the FileInfoton of the SPA Entry Point is not available.
_// Note that 503 is [legit code](https://github.com/thomsonreuters/CM-Well/blob/c3c68aa0aa214fb3debf045350ab14c18f0cad09/server/cmwell-cons/src/main/scala/ctl.scala#L726) in the eyes of cons._