### PR TITLE
adding `gqp` in consume. can be mixed with xg/yg, and takes precedenc…

### DIFF
--- a/server/cmwell-it/src/it/scala/cmwell/it/Helpers.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/Helpers.scala
@@ -47,6 +47,8 @@ trait Helpers { self: LazyLogging =>
   val _out = cmw / "_out"
   val _in = cmw / "_in"
   val _ow = cmw / "_ow"
+  val _consume = cmw / "_consume"
+  val _bulkconsume = cmw / "_bulk-consume"
   val cmt = cmw / "cmt" / "cm" / "test"
   val metaNs = cmw / "meta" / "ns"
   val textPlain = Some("text/plain;charset=UTF-8")

--- a/server/cmwell-it/src/it/scala/cmwell/it/SearchTests.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/SearchTests.scala
@@ -199,6 +199,36 @@ class SearchTests extends AsyncFunSpec with Matchers with Inspectors with Helper
       }
     }
 
+    ///sws.geonames.org/?op=search&recursive&qp=type.rdf::http://xmlns.com/foaf/0.1/Document&gqp=<isDefinedBy.rdfs[countryCode.geonames::US]
+    val gqpFiltering = executeAfterCompletion(f1){
+      spinCheck(1.second,true)(Http.get(
+        uri = path,
+        queryParams = List(
+          "op" -> "search",
+          "format" -> "json",
+          "pretty" -> "",
+          "debug-info" -> "",
+          "recursive" -> "",
+          "qp" -> "type.rdf::http://xmlns.com/foaf/0.1/Document",
+          "gqp" -> "<isDefinedBy.rdfs[countryCode.geonames::US]"))){ r =>
+        (Json.parse(r.payload) \ "results" \ "total": @unchecked) match {
+          case JsDefined(JsNumber(n)) => n.intValue() == 2
+        }
+      }.map { res =>
+        withClue(res) {
+          val j = Json.parse(res.payload)
+          val total = (j \ "results" \ "total").as[Int]
+          total should be(7)
+          val length = (j \ "results" \ "length").as[Int]
+          length should be(2)
+          (j \ "results" \ "infotons").toOption.fold(fail("son.results.infotons was not found")) {
+            case JsArray(infotons) => infotons should have size(2)
+            case notArray => fail(s"json.results.infotons was not an array[$notArray]")
+          }
+        }
+      }
+    }
+
     val ex2unitPF: PartialFunction[Throwable,Unit] = {
       case _: Throwable => ()
     }
@@ -210,6 +240,7 @@ class SearchTests extends AsyncFunSpec with Matchers with Inspectors with Helper
       _ <- sortByAltitude.recover(ex2unitPF)
       _ <- sortByScoreFilterByIL.recover(ex2unitPF)
       _ <- recursiveSearch.recover(ex2unitPF)
+      _ <- gqpFiltering.recover(ex2unitPF)
     } yield Seq(293846, 293918, 294640, 294904, 5052287, 6342919, 6468007)).flatMap { seq =>
       Future.traverse(seq){ n =>
         val aboutPath =  path / n.toString / "about.rdf"
@@ -282,13 +313,13 @@ class SearchTests extends AsyncFunSpec with Matchers with Inspectors with Helper
     it("get sorted by altitude (some share property)")(sortByAltitude)
     it("get sorted by system.score (filtered by qp)")(sortByScoreFilterByIL)
     it("get nested object using recursive query param")(recursiveSearch)
+    it("filter results with gqp indirect properties")(gqpFiltering)
     describe("delete infotons and search for in") {
       it("succeed deleting nested objects")(deleteAbouts)
       it("not get nested objects using recursive query param after deletes")(recursiveSearch2)
       it("get nested deleted objects using recursive and with-deleted after deletes")(recursiveSearch3)
       it("get nested deleted & historic objects using recursive and with-history after deletes")(recursiveSearch4)
     }
-    //TODO: replicate sort-by tests to old it?
     //TODO: dcSync style search
   }
 }

--- a/server/cmwell-ws/app/Parsers.scala
+++ b/server/cmwell-ws/app/Parsers.scala
@@ -453,12 +453,16 @@ package util {
 
     private def paths: Parser[PathsExpansion] = repsep(path, "|") ^^ PathsExpansion.apply
 
-    def getPathsExpansionFunctions(ygInput: String): Try[PathsExpansion] = {
-      if (ygInput.isEmpty) scala.util.Failure(new IllegalArgumentException("yg empty input"))
+    def getPathsExpansionFunctions(ygInput: String): Try[PathsExpansion] = getPathExpansions(ygInput,"yg")
+
+    def getGQPs(gqpInput: String): Try[PathsExpansion] = getPathExpansions(gqpInput,"gqp")
+
+    def getPathExpansions(input: String, api: String): Try[PathsExpansion] = {
+      if (input.isEmpty) scala.util.Failure(new IllegalArgumentException(s"$api empty input"))
       else {
-        parseAll(paths, ygInput) match {
+        parseAll(paths, input) match {
           case Success(functions, _) => USuccess(functions)
-          case NoSuccess(msg, _) => scala.util.Failure(new IllegalArgumentException(s"error: $msg, accured while parsing: $ygInput"))
+          case NoSuccess(msg, _) => scala.util.Failure(new IllegalArgumentException(s"error: $msg, accured while parsing: $input"))
         }
       }
     }

--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -1541,9 +1541,9 @@ callback=< [URL] >
                     }
                   }
                   case None => gqpModified.map { gqpFilteredInfotons =>
-                    if(gqp) true -> unmodifiedSearchResult
+                    if(!gqp) true -> unmodifiedSearchResult
                     else true -> unmodifiedSearchResult.copy(
-                      length = gqpFilteredInfotons.size,
+                      length = gqpFilteredInfotons.length,
                       infotons = gqpFilteredInfotons
                     )
                   }

--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -1066,6 +1066,7 @@ callback=< [URL] >
     //properties that needs to be re-sent every iteration
     val xg = request.getQueryString("xg")
     val (yg,ygChunkSize) = request.getQueryString("yg").fold(Option.empty[String] -> 0)(Some(_) -> request.getQueryString("yg-chunk-size").flatMap(asInt).getOrElse(10))
+    val (gqp,gqpChunkSize) = request.getQueryString("gqp").fold(Option.empty[String] -> 0)(Some(_) -> request.getQueryString("gqp-chunk-size").flatMap(asInt).getOrElse(10))
     val (requestedFormat,withData) = {
       val (f,b) = extractInferredFormatWithData(request,"json")
       f -> (b || yg.isDefined || xg.isDefined) //infer `with-data` implicitly, and don't fail the request
@@ -1158,13 +1159,13 @@ callback=< [URL] >
 
               // last chunk
               if (results.length >= total)
-                expandSearchResultsForSortedIteration(results, sortedConsumeState.copy(from = idxT), total, formatter, contentType, xg, yg, ygChunkSize, nbg)
+                expandSearchResultsForSortedIteration(results, sortedConsumeState.copy(from = idxT), total, formatter, contentType, xg, yg, gqp, ygChunkSize, gqpChunkSize, nbg)
               //regular chunk with more than 1 indexTime
               else if (results.exists(_.indexTime != idxT)) {
                 val newResults = results.filter(_.indexTime < idxT)
                 val id = sortedConsumeState.copy(from = idxT - 1)
                 //expand the infotons with yg/xg, but only after filtering out the infotons with the max indexTime
-                expandSearchResultsForSortedIteration(newResults, id, total, formatter, contentType, xg, yg, ygChunkSize, nbg)
+                expandSearchResultsForSortedIteration(newResults, id, total, formatter, contentType, xg, yg, gqp, ygChunkSize, gqpChunkSize, nbg)
               }
               //all the infotons in current chunk have the same indexTime
               else {
@@ -1186,7 +1187,7 @@ callback=< [URL] >
                 scrollFuture.flatMap {
                   //if by pure luck, the chunk length is exactly equal to the number of infotons in cm-well containing this same indexTime
                   case (_,hits) if hits <= results.size =>
-                    expandSearchResultsForSortedIteration(results, sortedConsumeState.copy(from = idxT), total, formatter, contentType, xg, yg, ygChunkSize, nbg)
+                    expandSearchResultsForSortedIteration(results, sortedConsumeState.copy(from = idxT), total, formatter, contentType, xg, yg, gqp, ygChunkSize, gqpChunkSize, nbg)
                   //if we were asked to expand chunk, but need to respond with a chunked response (workaround: try increasing length or search directly with adding `system.indexTime::${idxT}`)
                   case _ if xg.isDefined || yg.isDefined =>
                     Future.successful(UnprocessableEntity(s"encountered a large chunk which cannot be expanded using xg/yg. (indexTime=$idxT)"))
@@ -1218,13 +1219,15 @@ callback=< [URL] >
                                             contentType: String,
                                             xg: Option[String],
                                             yg: Option[String],
+                                            gqp: Option[String],
                                             ygChunkSize: Int,
+                                            gqpChunkSize: Int,
                                             nbg: Boolean): Future[Result] = {
 
     val id = ConsumeState.encode(sortedIteratorState)
 
     if (formatter.format.isThin) {
-      require(xg.isEmpty && yg.isEmpty, "Thin formats does not carry data, and thus cannot be expanded! (xg/yg supplied together with a thin format)")
+      require(xg.isEmpty && yg.isEmpty, "Thin formats does not carry data, and thus cannot be expanded! (xg/yg/gqp supplied together with a thin format)")
       val body = FormatterManager.formatFormattableSeq(newResults, formatter)
       Future.successful(Ok(body)
         .as(contentType)
@@ -1248,47 +1251,50 @@ callback=< [URL] >
           }
         }
 
-        //TODO: xg/yg handling should be factor out (DRY principle)
-        val ygModified = yg match {
-          case Some(ygp) if newInfotons.nonEmpty => {
-            pathExpansionParser(ygp, newInfotons, ygChunkSize, cmwellRDFHelper, typesCache(nbg), nbg).map {
-              case (ok, infotonsAfterYg) => ok -> infotonsAfterYg
+        val gqpModified = gqp.fold(Future.successful(newInfotons))(gqpFilter(_,newInfotons,cmwellRDFHelper,typesCache(nbg),gqpChunkSize,nbg))
+        gqpModified.flatMap { infotonsAfterGQP =>
+          //TODO: xg/yg handling should be factor out (DRY principle)
+          val ygModified = yg match {
+            case Some(ygp) if infotonsAfterGQP.nonEmpty => {
+              pathExpansionParser(ygp, infotonsAfterGQP, ygChunkSize, cmwellRDFHelper, typesCache(nbg), nbg).map {
+                case (ok, infotonsAfterYg) => ok -> infotonsAfterYg
+              }
             }
+            case _ => Future.successful(true -> infotonsAfterGQP)
           }
-          case _ => Future.successful(true -> newInfotons)
-        }
 
-        ygModified.flatMap {
-          case (false, infotonsAfterYg) => {
-            val body = FormatterManager.formatFormattableSeq(infotonsAfterYg, formatter)
-            val result = InsufficientStorage(body)
-              .as(contentType)
-              .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - newInfotons.length).toString)
-            Future.successful(result)
-          }
-          case (true, infotonsAfterYg) if infotonsAfterYg.isEmpty || xg.isEmpty => {
-            val body = FormatterManager.formatFormattableSeq(infotonsAfterYg, formatter)
-            val result = {
-              if (newInfotonsBoxes.exists(_._1.isEmpty)) PartialContent(body)
-              else Ok(body)
+          ygModified.flatMap {
+            case (false, infotonsAfterYg) => {
+              val body = FormatterManager.formatFormattableSeq(infotonsAfterYg, formatter)
+              val result = InsufficientStorage(body)
+                .as(contentType)
+                .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - infotonsAfterGQP.length).toString)
+              Future.successful(result)
             }
+            case (true, infotonsAfterYg) if infotonsAfterYg.isEmpty || xg.isEmpty => {
+              val body = FormatterManager.formatFormattableSeq(infotonsAfterYg, formatter)
+              val result = {
+                if (newInfotonsBoxes.exists(_._1.isEmpty)) PartialContent(body)
+                else Ok(body)
+              }
 
-            Future.successful(result
-              .as(contentType)
-              .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - newInfotonsBoxes.length).toString))
-          }
-          case (true, infotonsAfterYg) => {
-            deepExpandGraph(xg.get, infotonsAfterYg,cmwellRDFHelper,typesCache(nbg),nbg).map {
-              case (_, infotonsAfterXg) =>
-                val body = FormatterManager.formatFormattableSeq(infotonsAfterXg, formatter)
-                val result = {
-                  if (newInfotonsBoxes.exists(_._1.isEmpty)) PartialContent(body)
-                  else Ok(body)
-                }
+              Future.successful(result
+                .as(contentType)
+                .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - newInfotonsBoxes.length).toString))
+            }
+            case (true, infotonsAfterYg) => {
+              deepExpandGraph(xg.get, infotonsAfterYg, cmwellRDFHelper, typesCache(nbg), nbg).map {
+                case (_, infotonsAfterXg) =>
+                  val body = FormatterManager.formatFormattableSeq(infotonsAfterXg, formatter)
+                  val result = {
+                    if (newInfotonsBoxes.exists(_._1.isEmpty)) PartialContent(body)
+                    else Ok(body)
+                  }
 
-                result
-                  .as(contentType)
-                  .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - newInfotonsBoxes.length).toString)
+                  result
+                    .as(contentType)
+                    .withHeaders("X-CM-WELL-POSITION" -> id, "X-CM-WELL-N-LEFT" -> (total - newInfotonsBoxes.length).toString)
+              }
             }
           }
         }


### PR DESCRIPTION
…e. syntax is identical to yg