### PR TITLE
STP - adding logs+flow fixes+config fix (second try)

### DIFF
--- a/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/HttpConnections.scala
+++ b/server/cmwell-data-tools/src/main/scala/cmwell/tools/data/utils/akka/HttpConnections.scala
@@ -21,12 +21,13 @@ import akka.http.scaladsl._
 import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
 import akka.stream.Materializer
 import cmwell.tools.data.utils.logging.LabelId
+import com.typesafe.config.ConfigFactory
 
 object HttpConnections extends DataToolsConfig {
 
   def outgoingConnection(host: String, port: Int, protocol: String = "http")(implicit system: ActorSystem, label: Option[LabelId] = None) = {
     val userAgent = label.fold(s"cmwell-data-tools using akka-http/${config.getString("akka.version")}")(l => s"cmwell-data-tools ${l.id}")
-    val settings = ClientConnectionSettings(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent")
+    val settings = ClientConnectionSettings(ConfigFactory.parseString(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent").withFallback(config))
 
     protocol match {
       case "https" => Http().outgoingConnectionHttps(host, port, settings = settings)
@@ -36,7 +37,7 @@ object HttpConnections extends DataToolsConfig {
 
   def newHostConnectionPool[T](host: String, port: Int, protocol: String = "http")(implicit system: ActorSystem, mat: Materializer, label: Option[LabelId] = None) = {
     val userAgent = label.fold(s"cmwell-data-tools using akka-http/${config.getString("akka.version")}")(l => s"cmwell-data-tools ${l.id}")
-    val settings = ConnectionPoolSettings(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent")
+    val settings = ConnectionPoolSettings(ConfigFactory.parseString(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent").withFallback(config))
 
     protocol match {
       case "https" => Http().newHostConnectionPoolHttps[T](host, port, settings = settings)
@@ -46,7 +47,7 @@ object HttpConnections extends DataToolsConfig {
 
   def cachedHostConnectionPool[T](host: String, port: Int, protocol: String = "http")(implicit system: ActorSystem, mat: Materializer, label: Option[LabelId] = None) = {
     val userAgent = label.fold(s"cmwell-data-tools using akka-http/${config.getString("akka.version")}")(l => s"cmwell-data-tools ${l.id}")
-    val settings = ConnectionPoolSettings(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent")
+    val settings = ConnectionPoolSettings(ConfigFactory.parseString(s"akka.http.host-connection-pool.client.user-agent-header=$userAgent").withFallback(config))
 
     protocol match {
       case "https" => Http().cachedHostConnectionPoolHttps[T](host, port, settings = settings)


### PR DESCRIPTION
1. adding logs to STP stand alone to print the reason the stream finished
2. fix the alsoToMat in BufferFillerActor to propagate the stream end to the upstream
3. fix connection pools to not just use the library defaults but also the application.conf values