### PR TITLE
sbt and scala patch upgrades

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -21,7 +21,7 @@ sys.env.get("BUILD_NUMBER") match {
   )
 }
 
-scalaVersion in Global := "2.11.11"
+scalaVersion in Global := "2.11.12"
 //javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 initialize := {
   val _ = initialize.value

--- a/server/project/build.properties
+++ b/server/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/server/project/build.sbt
+++ b/server/project/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++=  Seq(
 
 val s = Seq(
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
-  scalaVersion := "2.10.6"
+  scalaVersion := "2.10.7"
 )
 
 sourceGenerators in Compile += Def.task {

--- a/server/project/project/build.properties
+++ b/server/project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
scala released a new patch for all supported minor versions:
http://scala-lang.org/news/security-update-nov17.html
TL;DR:
security update. vulnerability is exposed when fsc is used, or when running scala scripts.
Since cmwell-cons runs such scripts during deployment, we are affected.