### PR TITLE
explicitly adding HTTP scheme when no scheme provided, but port is

### DIFF
--- a/server/cmwell-util/src/main/scala/cmwell/util/http/SimpleHttpClient.scala
+++ b/server/cmwell-util/src/main/scala/cmwell/util/http/SimpleHttpClient.scala
@@ -137,7 +137,7 @@ object SimpleHttpClient extends LazyLogging {
 
   private def mkURI(uri: String, queryParams: Seq[(String,String)]) = {
 
-    val noSchemeWithPort = uri.matches("[^:]+:\\d+")
+    val noSchemeWithPort = uri.matches("[^:/]+:\\d+")
     if (queryParams.isEmpty && !noSchemeWithPort) uri
     else {
       val sb = new StringBuilder

--- a/server/cmwell-util/src/main/scala/cmwell/util/http/SimpleHttpClient.scala
+++ b/server/cmwell-util/src/main/scala/cmwell/util/http/SimpleHttpClient.scala
@@ -137,7 +137,7 @@ object SimpleHttpClient extends LazyLogging {
 
   private def mkURI(uri: String, queryParams: Seq[(String,String)]) = {
 
-    val noSchemeWithPort = uri.matches("\\w+:\\d+")
+    val noSchemeWithPort = uri.matches("[^:]+:\\d+")
     if (queryParams.isEmpty && !noSchemeWithPort) uri
     else {
       val sb = new StringBuilder


### PR DESCRIPTION
 Which causes akka's UriParser to fail: https://github.com/akka/akka-http/issues/1547 
This commit fixes #309 