### PR TITLE
Dc-Sync: ignore infotons with a faulty index time in CAS

### DIFF
--- a/server/cmwell-dc/src/main/scala/cmwell/dc/stream/DataCenterSyncManager.scala
+++ b/server/cmwell-dc/src/main/scala/cmwell/dc/stream/DataCenterSyncManager.scala
@@ -573,7 +573,8 @@ class DataCenterSyncManager(dstServersVec: Vector[(String, Option[Int])], manual
 
   def createSyncingEngine(dcInfo: DcInfo): RunnableGraph[SyncerMaterialization] = {
     val localDecider: Supervision.Decider = { e: Throwable =>
-      logger.error(s"The stream of data center id ${dcInfo.id} from location ${dcInfo.location} got an exception caught in local decider. It will be stopped. The exception is:", e)
+      //The decider is not used anymore the restart is done by watching the Future[Done] of the stream - no need for the log print (It's left for completeness until the decider is totally removed.
+      logger.debug(s"The stream of data center id ${dcInfo.id} from location ${dcInfo.location} got an exception caught in local decider. It inner stream will be stopped (the whole one may continue). The exception is:", e)
       Supervision.Stop
     }
     val tsvSource = dcInfo.tsvFile.fold(TsvRetriever(dcInfo, localDecider).mapConcat(identity))(_ => TsvRetrieverFromFile(dcInfo))

--- a/server/cmwell-dc/src/main/scala/cmwell/dc/stream/InfotonRetriever.scala
+++ b/server/cmwell-dc/src/main/scala/cmwell/dc/stream/InfotonRetriever.scala
@@ -40,7 +40,8 @@ import scala.util.{Failure, Success, Try}
 object InfotonRetriever extends LazyLogging {
 
   type RetrieveInput = Seq[InfotonData]
-  type RetrieveOutput = scala.collection.immutable.Seq[InfotonData]
+  //Sequence of (InfotonData, Option[Read indexTime from cassandra(_out) )
+  type RetrieveOutput = scala.collection.immutable.Seq[(InfotonData, Option[Long])]
 
   case class RetrieveStateStatus(retriesLeft: Int, lastException: Option[Throwable])
 
@@ -50,11 +51,11 @@ object InfotonRetriever extends LazyLogging {
   val initialRetrieveSingleStatus = RetrieveStateStatus(Settings.initialSingleRetrieveRetryCount, None)
 
 
-  case class ParsedNquad(path: String, nquad: ByteString)
+  case class ParsedNquad(path: String, nquad: ByteString, indexTime: Option[Long])
 
-  case class RetrieveTotals(parsed: Map[String, ByteStringBuilder], unParsed: ByteStringBuilder)
+  case class RetrieveTotals(parsed: Map[String, (ByteStringBuilder, Option[Long])], unParsed: ByteStringBuilder)
 
-  val breakOut = scala.collection.breakOut[RetrieveInput, InfotonData, RetrieveOutput]
+  val breakOut = scala.collection.breakOut[RetrieveInput, (InfotonData, Option[Long]) , RetrieveOutput]
   val breakOut2 = scala.collection.breakOut[RetrieveInput, (Future[RetrieveInput], RetrieveState), List[(Future[RetrieveInput], RetrieveState)]]
 
   //The path will be unique for each bulk infoton got into the flow
@@ -75,21 +76,29 @@ object InfotonRetriever extends LazyLogging {
           case (Success(response), state) if response.status.isSuccess() => {
             response.entity.dataBytes
               .via(Framing.delimiter(endln, maximumFrameLength = maxStatementLength))
-              .fold(RetrieveTotals(state._1.map(im => (im.meta.path, new ByteStringBuilder)).toMap, new ByteStringBuilder)) { (totals, nquad) =>
+              .fold(RetrieveTotals(state._1.map(im => (im.meta.path, (new ByteStringBuilder, None))).toMap, new ByteStringBuilder)) { (totals, nquad) =>
                 totals.unParsed ++= nquad
                 val parsed: Option[ParsedNquad] = parseNquad(remoteUri, nquad)
-                parsed.foreach {
+                parsed.fold {
+                  RetrieveTotals(totals.parsed, totals.unParsed)
+                } {
                   p => totals.parsed.get(p.path) match {
                     case None => throw WrongPathGotException(s"Got path ${p.path} from _out that was not in the uuids request bulk: ${state._1.map(i => i.meta.uuid.utf8String + ":" + i.meta.path).mkString(",")}")
-                    case Some(builder) => builder ++= (p.nquad ++ endln)
+                    case Some((builder, _)) => {
+                      builder ++= (p.nquad ++ endln)
+                      val parsedTotals = p.indexTime.fold(totals.parsed)(_ => totals.parsed + (p.path -> (builder, p.indexTime)))
+                      RetrieveTotals(parsedTotals, totals.unParsed)
+                    }
                   }
                 }
-                RetrieveTotals(totals.parsed, totals.unParsed)
               }
               .map { totals =>
                 val parsedResult: Try[RetrieveOutput] = Success(state._1.map {
                   //todo: validity checks that the data arrived correctly. e.g. that the path could be retrieved from _out etc.
-                  im => InfotonData(im.meta, totals.parsed(im.meta.path).result)
+                  im => {
+                    val parsed: (ByteStringBuilder, Option[Long]) = totals.parsed(im.meta.path)
+                    (InfotonData(im.meta, parsed._1.result), parsed._2)
+                  }
                 }(breakOut))
                 (parsedResult, state, Option(totals.unParsed.result))
               }
@@ -118,7 +127,7 @@ object InfotonRetriever extends LazyLogging {
       .map(input => Future.successful(input) -> (input -> initialRetrieveBulkStatus))
       .via(Retry.concat(Settings.retrieveRetryQueueSize, retrieveFlow)(retryDecider(dcInfo.id, dcInfo.location)))
       .map {
-        case (Success(data), _) => data
+        case (Success(data), _) => data.map(_._1)
         case (Failure(e), _) => {
           logger.error(s"Data Center ID ${dcInfo.id} from location ${dcInfo.location}. Retrieve should never fail after retry.", e)
           throw e
@@ -136,8 +145,16 @@ object InfotonRetriever extends LazyLogging {
       !line.contains("/meta/sys#path")) {
       val uri = wrappedSubject.tail.init
       val path = cmwell.domain.FReference(uri).getCmwellPath
+      val indexTime = {
+        val pos = line.indexOf("/meta/sys#indexTime") + 22
+        //-1 + 22 == 21 - no match is found
+        if (pos == 21) None else {
+          val untilPos = line.indexOf('"', pos)
+          Some(line.substring(pos, untilPos).toLong)
+        }
+      }
       val nquad = ByteString(line)
-      Some(ParsedNquad(path, nquad))
+      Some(ParsedNquad(path, nquad, indexTime))
     }
     else None
   }
@@ -148,8 +165,10 @@ object InfotonRetriever extends LazyLogging {
   def checkResponseCreator(dataCenterId: String, location: String, decider: Decider)(response: (Try[RetrieveOutput], RetrieveState, Option[ByteString])): (Try[RetrieveOutput], RetrieveState) =
     response match {
       case (response@Success(res), state@(input, status), body) => {
-        val missingUuids = res.filter(_.data == empty)
-        if (missingUuids.isEmpty) {
+        val missingUuids = res.collect { case (id, _) if id.data == empty => id }
+        //uuids that the index time from cassandra is different from the one got from ES
+        val uuidsWithBadIndexTime = res.collect { case (id, casIndexTime) if casIndexTime.isDefined && id.meta.indexTime != casIndexTime.get => id }
+        if (missingUuids.isEmpty && uuidsWithBadIndexTime.isEmpty) {
           status.lastException.foreach { e =>
             val bulkCount = if (input.size > 1) Settings.initialBulkRetrieveRetryCount - status.retriesLeft + 1 else Settings.initialBulkRetrieveRetryCount + 1
             val singleCount = if (input.size > 1) 0 else Settings.initialSingleRetrieveRetryCount - status.retriesLeft + 1
@@ -157,9 +176,15 @@ object InfotonRetriever extends LazyLogging {
           }
           (response, state)
         }
+        else if (missingUuids.nonEmpty) {
+          val errorID = response.##
+          val ex = RetrieveMissingUuidException(s"Error ![$errorID]. Retrieve infotons failed. Some infotons don't have data. Data center ID $dataCenterId, using remote location $location missing uuids: ${missingUuids.map(i => i.meta.uuid.utf8String).mkString(",")}.")
+          logger.debug(s"Error ![$errorID]. Full response body was: $body")
+          (Failure(ex), (state._1, RetrieveStateStatus(state._2.retriesLeft, Some(ex))))
+        }
         else {
           val errorID = response.##
-          val ex = RetrieveException(s"Error ![$errorID]. Retrieve infotons failed. Some infotons don't have data. Data center ID $dataCenterId, using remote location $location missing uuids: ${missingUuids.map(i => i.meta.uuid.utf8String).mkString(",")}.")
+          val ex = RetrieveBadIndexTimeException(s"Error ![$errorID]. Retrieve infotons failed. Some infotons' indexTime has cas/es inconsistencies. Data center ID $dataCenterId, using remote location $location bad uuids: ${uuidsWithBadIndexTime.map(i => i.meta.uuid.utf8String).mkString(",")}.")
           logger.debug(s"Error ![$errorID]. Full response body was: $body")
           (Failure(ex), (state._1, RetrieveStateStatus(state._2.retriesLeft, Some(ex))))
         }
@@ -174,9 +199,17 @@ object InfotonRetriever extends LazyLogging {
           case e: FuturedBodyException =>
             logger.error(s"${e.getMessage} ${e.getCause.getMessage} No more retries will be done. Please use the red log to see the list of all the failed retrievals.")
             Util.errorPrintFuturedBodyException(e)
-          case e => logger.error(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} from $location failed. No more reties will be done. Please use the red log to see the list of all the failed retrievals. The exception is: ", e)
+            redlog.info(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} of path ${ingestSeq.head.meta.path} from $location failed.")
+          case e: RetrieveMissingUuidException =>
+            logger.error(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} from $location failed. No more reties will be done. Please use the red log to see the list of all the failed retrievals. The exception is:\n${e.getMessage}")
+            redlog.info(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} of path ${ingestSeq.head.meta.path} from $location failed. No uuid got from _out.")
+          case e: RetrieveBadIndexTimeException =>
+            logger.error(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} from $location failed. No more reties will be done. Please use the red log to see the list of all the failed retrievals. The exception is:\n${e.getMessage}")
+            redlog.info(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} of path ${ingestSeq.head.meta.path} from $location failed. IndexTime has cas/es inconsistency.")
+          case e =>
+            logger.error(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} from $location failed. No more reties will be done. Please use the red log to see the list of all the failed retrievals. The exception is: ", e)
+            redlog.info(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} of path ${ingestSeq.head.meta.path} from $location failed.")
         }
-        redlog.info(s"Data Center ID $dataCenterId: Retrieve of uuid ${ingestSeq.head.meta.uuid.utf8String} from $location failed.")
         Some(List.empty[(Future[RetrieveInput], RetrieveState)])
       }
       else if (ingestSeq.size == 1) {

--- a/server/cmwell-dc/src/main/scala/cmwell/dc/stream/MessagesTypesAndExceptions.scala
+++ b/server/cmwell-dc/src/main/scala/cmwell/dc/stream/MessagesTypesAndExceptions.scala
@@ -49,6 +49,8 @@ object MessagesTypesAndExceptions {
   case class CreateConsumeException(message: String, ex: Throwable = null) extends Exception(message, ex)
   case class WrongPathGotException(message: String) extends Exception(message)
   case class RetrieveException(message: String, ex: Throwable = null) extends Exception(message, ex)
+  case class RetrieveMissingUuidException(message: String, ex: Throwable = null) extends Exception(message, ex)
+  case class RetrieveBadIndexTimeException(message: String, ex: Throwable = null) extends Exception(message, ex)
   case class RetrieveTsvException(message: String, ex: Throwable = null) extends Exception(message, ex)
   case class IngestException(message: String, ex: Throwable = null) extends Exception(message, ex)
 

--- a/server/cmwell-ws/app/logic/CRUDServiceFS.scala
+++ b/server/cmwell-ws/app/logic/CRUDServiceFS.scala
@@ -652,7 +652,8 @@ class CRUDServiceFS @Inject()(tbg: NbgToggler)(implicit ec: ExecutionContext, sy
       val fields = Map("lastIdxT" -> Set[FieldValue](FLong(indexTime)),
         "dc" -> Set[FieldValue](FString(dc)))
       val fieldsWithFilter = fieldFilters.fold(fields)(ff => fields + ("qp" -> Set[FieldValue](FString(Encoder.encodeFieldFilter(ff)))))
-      VirtualInfoton(ObjectInfoton(s"/proc/dc/$dc", Settings.dataCenter, None, fieldsWithFilter))
+      val fieldsWithFilterAndWh = fieldsWithFilter + ("with-history" -> Set[FieldValue](FBoolean(withHistory)))
+      VirtualInfoton(ObjectInfoton(s"/proc/dc/$dc", Settings.dataCenter, None, fieldsWithFilterAndWh))
     }
 
     ftsService(nbg).getLastIndexTimeFor(dc, withHistory = withHistory, fieldFilters = fieldFilters).map(lOpt => Some(mkVirtualInfoton(lOpt.getOrElse(0L))))


### PR DESCRIPTION
1. Remove the error printed when TSV retrieve failed. It's only a warning and can be retried.
2. Check that the index time from ES and from CAS match. If not ignore this infoton and write it to the red log.
3. Add the relevant with-history field for the dc virtual infotons in /proc/dc.
4. remove the full stack trace in log print for missing uuid exception