### PR TITLE
FTS failing initialization code is deffered to prevent ws crashing on…

### DIFF
--- a/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
+++ b/server/cmwell-fts/src/main/scala/cmwell/fts/FTSServiceES.scala
@@ -127,9 +127,9 @@ class FTSServiceES private(classPathConfigFile: String, waitForGreen: Boolean)
 
   loger.info (s"nodesInfo: $nodesInfo")
 
-  val localNodeId = client.admin().cluster().prepareNodesInfo().execute().actionGet().getNodesMap.asScala.filter{case (id, node) =>
+  lazy val localNodeId = client.admin().cluster().prepareNodesInfo().execute().actionGet().getNodesMap.asScala.filter{case (id, node) =>
     node.getHostname.equals(localHostName) && node.getNode.isDataNode
-  }.map{_._1}.head
+  }.map(_._1).head
   
   val clients:Map[String, Client] = isTransportClient match {
     case true =>


### PR DESCRIPTION
… startup

Exception:

Caused by: java.util.NoSuchElementException: next on empty iterator
        at scala.collection.Iterator$$anon$2.next(Iterator.scala:39)
        at scala.collection.Iterator$$anon$2.next(Iterator.scala:37)
        at scala.collection.IndexedSeqLike$Elements.next(IndexedSeqLike.scala:63)
        at scala.collection.IterableLike$class.head(IterableLike.scala:107)
        at scala.collection.mutable.ArrayBuffer.scala$collection$IndexedSeqOptimized$$super$head(ArrayBuffer.scala:48)
        at scala.collection.IndexedSeqOptimized$class.head(IndexedSeqOptimized.scala:126)
        at scala.collection.mutable.ArrayBuffer.head(ArrayBuffer.scala:48)
        at cmwell.fts.FTSServiceES.<init>(FTSServiceES.scala:132)
        at cmwell.fts.FTSServiceES$.getOne(FTSServiceES.scala:79)
        at logic.CRUDServiceFS.<init>(CRUDServiceFS.scala:92)
        at logic.CRUDServiceFS$$FastClassByGuice$$f0851614.newInstance(<generated>)

causing code:

val localNodeId = client.admin().cluster().prepareNodesInfo().execute().actionGet().getNodesMap.asScala.filter{case (id, node) =>
  node.getHostname.equals(localHostName) && node.getNode.isDataNode
}.map{_._1}.head

hotfix is to make this lazy