### PR TITLE
"ironing" dots to underscore

### DIFF
--- a/server/cmwell-common/src/main/scala/cmwell/common/formats/AbstractJsonSerializer.scala
+++ b/server/cmwell-common/src/main/scala/cmwell/common/formats/AbstractJsonSerializer.scala
@@ -40,14 +40,14 @@ class AbstractJsonSerializer {
 trait NsSplitter {
   def splitNamespaceField(field: String) = field.lastIndexOf(".") match {
     case -1 => "nn" -> field
-    case i => field.substring(i+1) -> field.substring(0,i)
+    case i => field.substring(i+1) -> field.substring(0,i).replace('.','_')
   }
 
   def reverseNsTypedField(field: String) = {
     if(field.startsWith("system.") || field.startsWith("content.") || field.startsWith("link.")) field
     else {
       val (ns, typedField) = splitNamespaceField(field)
-      "fields." + ns + "." + typedField
+      "fields." + ns + "." + typedField.replace('.','_')
     }
   }
 }


### PR DESCRIPTION
converting dots to underscore to safe guard from ES unintended nesting.
change was checked locally using:
```
$ curl localhost:9000/_in?format=ntriples -H "X-CM-WELL-TOKEN: ... " --data-binary '<http://some.made/up/domain> <http://and.made.up/field#with.dots> "and value" .'
{"success":true}
$ curl -s localhost:9000/proc/fields?format=json | jq -r '.fields.fields[]' | grep -E 'with(_|.)dots'
with_dots.eadC6A:string
$ curl -s 'localhost:9000/?op=search&recursive&qp=with.dots.$eadC6A:&format=json' | jq '[.results.total,.results.infotons[0].system.path]'
[
  1,
  "/some.made/up/domain"
]
$ curl -s 'localhost:9000/?op=search&recursive&qp=with_dots.$eadC6A:&format=json' | jq '[.results.total,.results.infotons[0].system.path]'
[
  1,
  "/some.made/up/domain"
]
```