### PR TITLE
Update the version of sbt-coursier to 1.0.0

### DIFF
--- a/server/project/cmwell-build-plugin/build.sbt
+++ b/server/project/cmwell-build-plugin/build.sbt
@@ -5,6 +5,6 @@ name := "cmwell-build-plugin"
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.5.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.alpinenow" % "junit_xml_listener" % "0.5.1")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC11")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 
 sbtPlugin := true 


### PR DESCRIPTION
Without this change, the build could fail to resolve some artifacts with repository caches cleared. This problem showed up after the Scala upgrade.