### PR TITLE
remove the type check in DcChecker

### DIFF
--- a/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/DcChecker.scala
+++ b/server/cmwell-controller/src/main/scala/cmwell/ctrl/checkers/DcChecker.scala
@@ -48,7 +48,7 @@ object DcChecker  extends Checker with RestarterChecker with LazyLogging {
 
   private def getActiveDcSyncs(host : String) : Future[Set[ActiveDcSync]] = {
 
-     Http.get(s"http://$host/meta/sys/dc/?op=search&qp=type::remote&format=json&with-data").map {
+     Http.get(s"http://$host/meta/sys/dc/?op=search&format=json&with-data").map {
       r =>
         val json: JsValue = Json.parse(r.payload)
         val JsDefined(JsArray(infotons)) = json.\("results").\("infotons")


### PR DESCRIPTION
In case there was no sync in the sytem the type field won't exit.
It will solve the field not found exception in the logs every 30 seconds