### PR TITLE
422 error code removal.

### DIFF
--- a/server/cmwell-common/src/main/scala/cmwell/common/formats/JsonSerializer.scala
+++ b/server/cmwell-common/src/main/scala/cmwell/common/formats/JsonSerializer.scala
@@ -380,7 +380,7 @@ object JsonSerializer extends AbstractJsonSerializer with LazyLogging {
               case _ => "utf-8"
             }
             jsonGenerator.writeStringField("data", new String(data, charset))
-          }else if(!omitBinaryData){
+          } else if(!omitBinaryData) {
             jsonGenerator.writeBinaryField("base64-data", data)
           }
         }

--- a/server/cmwell-it/src/it/scala/cmwell/it/APIFunctionalityTests.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/APIFunctionalityTests.scala
@@ -56,6 +56,16 @@ class APIFunctionalityTests extends AsyncFunSpec
 
   describe("CM-Well REST API"){
 
+    val antiJenaVcardRFFIngest = {
+      val vcardRdf = Source.fromURL(this.getClass.getResource("/anti_jena_ns.xml")).mkString
+      Http.post(_in, vcardRdf, Some("application/rdf+xml;charset=UTF-8"), List("format" -> "rdfxml"), tokenHeader)
+    }
+
+    val complicatedInferenceIngest = {
+      val zzz = Source.fromURL(this.getClass.getResource("/zzz.rdf")).mkString
+      Http.post(_in, zzz, Some("application/rdf+xml;charset=UTF-8"), List("format" -> "rdfxml"), tokenHeader)
+    }
+
     describe("post sem-web doc to _in") {
       describe("with RDF format") {
 
@@ -69,8 +79,7 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
 
         it("should post with anti jena new onthology"){
-          val vcardRdf = Source.fromURL(this.getClass.getResource("/anti_jena_ns.xml")).mkString
-          Http.post(_in, vcardRdf, Some("application/rdf+xml;charset=UTF-8"), List("format" -> "rdfxml"), tokenHeader).map { res =>
+          antiJenaVcardRFFIngest.map { res =>
             withClue(res) {
               Json.parse(res.payload) should be(jsonSuccess)
             }
@@ -78,8 +87,7 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
 
         it("should post with complicated inference logic"){
-          val zzz = Source.fromURL(this.getClass.getResource("/zzz.rdf")).mkString
-          Http.post(_in, zzz, Some("application/rdf+xml;charset=UTF-8"), List("format" -> "rdfxml"), tokenHeader).map { res =>
+          complicatedInferenceIngest.map { res =>
             withClue(res) {
               Json.parse(res.payload) should be(jsonSuccess)
             }
@@ -565,31 +573,41 @@ class APIFunctionalityTests extends AsyncFunSpec
           |}
         """.stripMargin)
         val g = clf / "ce" / "GH"
-        Http.get(g, List("format" -> "json")).map { res =>
-          withClue(res) {
-            val jv = Json.parse(res.payload).transform(uuidDateEraser).get
-            jv shouldEqual expected
+        executeAfterCompletion(antiJenaVcardRFFIngest)(scheduleFuture(10.seconds){
+          Http.get(g, List("format" -> "json")).map { res =>
+            withClue(res) {
+              val jv = Json.parse(res.payload).transform(uuidDateEraser).get
+              jv shouldEqual expected
+            }
           }
-        }
+        })
       }
 
       it("should deal with complicated prefix inference logic") {
-        val expectedNt = Set[String](s"""<http://example.org/hochgi> <${cmw.url}/meta/sys#type> "ObjectInfoton" .""",
-            """<http://example.org/hochgi> <http://zzz.me/2014/ZzZzz/2014-06-24#FN> "G H" .""",
-            """<http://example.org/hochgi> <http://zzz.me/2014/ZzZzz/2014-06-24#GENDER> "Male" .""",
-            """<http://example.org/hochgi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://zzz.me/2014/ZzZzz/2014-06-24#Individual> .""",
-            s"""<http://example.org/hochgi> <http://localhost:9000/meta/sys#dataCenter> "$dcName" .""",
-            """<http://example.org/hochgi> <http://localhost:9000/meta/sys#parent> "/example.org" .""",
-            """<http://example.org/hochgi> <http://localhost:9000/meta/sys#path> "/example.org/hochgi" ."""
+        val expectedNt = Set[String](
+          s"""<http://example.org/hochgi> <${cmw.url}/meta/sys#type> "ObjectInfoton" .""",
+          """<http://example.org/hochgi> <http://zzz.me/2014/ZzZzz/2014-06-24#FN> "G H" .""",
+          """<http://example.org/hochgi> <http://zzz.me/2014/ZzZzz/2014-06-24#GENDER> "Male" .""",
+          """<http://example.org/hochgi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://zzz.me/2014/ZzZzz/2014-06-24#Individual> .""",
+          s"""<http://example.org/hochgi> <http://localhost:9000/meta/sys#dataCenter> "$dcName" .""",
+          """<http://example.org/hochgi> <http://localhost:9000/meta/sys#parent> "/example.org" .""",
+          """<http://example.org/hochgi> <http://localhost:9000/meta/sys#path> "/example.org/hochgi" ."""
         )
 
-        Http.get(exampleOrg./("hochgi"), List("format" -> "ntriples")).map{ body =>
-          body.status should be >=200
-          body.status should be <400 //status should be OK
+        executeAfterCompletion(complicatedInferenceIngest)(scheduleFuture(10.seconds) {
+          Http.get(exampleOrg./("hochgi"), List("format" -> "ntriples")).map { body =>
+            body.status should be >= 200
+            body.status should be < 400 //status should be OK
           def mSys(s: String) = s"/meta/sys#$s"
-          val res = (new String(body.payload, "UTF-8")).split('\n').filterNot(t => t.contains(mSys("lastModified")) || t.contains(mSys("uuid")) || t.contains(mSys("indexTime")))
-          res.toSet shouldEqual expectedNt
-        }
+
+            val res = new String(body.payload, "UTF-8").split('\n').filterNot { t =>
+              t.contains(mSys("lastModified")) ||
+                t.contains(mSys("uuid"))       ||
+                t.contains(mSys("indexTime"))
+            }
+            res.toSet shouldEqual expectedNt
+          }
+        })
       }
 
       it("should verify ZzZzz meta creation") {
@@ -1005,10 +1023,12 @@ class APIFunctionalityTests extends AsyncFunSpec
       val f09 = f00.flatMap(_ => Http.get(mZ, List("xg" -> "$http://purl.org/vocab/relationship/colleagueOf$>$http://purl.org/vocab/relationship/employedBy$>$http://purl.org/vocab/relationship/mentorOf$>$http://purl.org/vocab/relationship/friendOf$>$http://purl.org/vocab/relationship/worksWith$>$http://purl.org/vocab/relationship/parentOf$","format" -> "json")))
       val f10 = f00.flatMap(_ => Http.get(mZ, List("xg" -> "colleagueOf.rel>employedBy.rel>mentorOf.rel>friendOf.rel>worksWith.rel>parentOf.rel","format" -> "json")))
       val f11 = f00.flatMap(_ => Http.get(mZ, List("xg" -> "colleagueOf.rel[doesNotExist:]>employedBy.rel>mentorOf.rel>friendOf.rel>worksWith.rel>parentOf.rel","format" -> "json")))
-      val f12 = f00.flatMap(_ => Http.get(cKent, List("yg" -> s"<neighborOf.$$${ns.rel}>worksWith.$$${ns.rel}|<neighborOf.$$${ns.rel}<friendOf.$$${ns.rel}<mentorOf.$$${ns.rel}>knowsByReputation.$$${ns.rel}<collaboratesWith.$$${ns.rel}","format" -> "json")))
-      val f13 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<$http://purl.org/vocab/relationship/neighborOf$>$http://purl.org/vocab/relationship/worksWith$|<$http://purl.org/vocab/relationship/neighborOf$<$http://purl.org/vocab/relationship/friendOf$<$http://purl.org/vocab/relationship/mentorOf$>$http://purl.org/vocab/relationship/knowsByReputation$<$http://purl.org/vocab/relationship/collaboratesWith$","format" -> "json")))
-      val f14 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<neighborOf.rel>worksWith.rel|<neighborOf.rel<friendOf.rel<mentorOf.rel>knowsByReputation.rel<collaboratesWith.rel","format" -> "json")))
-      val f15 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<neighborOf.rel[active.bold::true]>worksWith.rel[active.bold::false]|<neighborOf.rel[active.bold::true]<friendOf.rel[doesNotExist::SomeValue]<mentorOf.rel>knowsByReputation.rel<collaboratesWith.rel","format" -> "json")))
+      val f12 = f00.flatMap(_ => Http.get(mZ, List("xg" -> "colleagueOf.rel[system.path:/not/real]>employedBy.rel>mentorOf.rel>friendOf.rel>worksWith.rel>parentOf.rel","format" -> "json")))
+      val f13 = f00.flatMap(_ => Http.get(cKent, List("yg" -> s"<neighborOf.$$${ns.rel}>worksWith.$$${ns.rel}|<neighborOf.$$${ns.rel}<friendOf.$$${ns.rel}<mentorOf.$$${ns.rel}>knowsByReputation.$$${ns.rel}<collaboratesWith.$$${ns.rel}","format" -> "json")))
+      val f14 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<$http://purl.org/vocab/relationship/neighborOf$>$http://purl.org/vocab/relationship/worksWith$|<$http://purl.org/vocab/relationship/neighborOf$<$http://purl.org/vocab/relationship/friendOf$<$http://purl.org/vocab/relationship/mentorOf$>$http://purl.org/vocab/relationship/knowsByReputation$<$http://purl.org/vocab/relationship/collaboratesWith$","format" -> "json")))
+      val f15 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<neighborOf.rel>worksWith.rel|<neighborOf.rel<friendOf.rel<mentorOf.rel>knowsByReputation.rel<collaboratesWith.rel","format" -> "json")))
+      val f16 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<neighborOf.rel[active.bold::true]>worksWith.rel[active.bold::false]|<neighborOf.rel[active.bold::true]<friendOf.rel[doesNotExist::SomeValue]<mentorOf.rel>knowsByReputation.rel<collaboratesWith.rel","format" -> "json")))
+      val f17 = f00.flatMap(_ => Http.get(cKent, List("yg" -> "<neighborOf.rel[active.bold::true]>worksWith.rel[active.bold::false]|<neighborOf.rel[active.bold::true]<friendOf.rel[system.path:/not/real]<mentorOf.rel>knowsByReputation.rel<collaboratesWith.rel","format" -> "json")))
 
       it("should post N-Triple files") {
         Future.traverse(Seq("/relationships.nt","/relationships2.nt")) { file =>
@@ -1090,7 +1110,7 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
       }
 
-      it("should NOT expand 6 levels deep if guarded by a filter") {
+      it("should NOT to expand 6 levels deep if guarded by a non existed filter") {
         val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.net/Individuals/M_Z","parent":"/example.net/Individuals","dataCenter":"$dcName"},"fields":{"colleagueOf.rel":["http://example.net/Individuals/I_K"]}}]}"""
         val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
         f11.map { res =>
@@ -1103,18 +1123,20 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
       }
 
-      it("should allow paths expansion with yg flag with explicit $ namespace") {
-        val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/JohnSmith","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/SaraSmith"],"friendOf.rel":["http://example.org/Individuals/PeterParker"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/RonaldKhun","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/MartinOdersky"],"category.bold":["deals","news"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/HarryMiller","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/NatalieMiller"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/DonaldDuck","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"knowsByReputation.rel":["http://example.org/Individuals/MartinOdersky"],"active.bold":["true"],"mentorOf.rel":["http://example.org/Individuals/JohnSmith"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/ClarkKent","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/PeterParker","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"active.bold":["true"],"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/MartinOdersky","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/RonaldKhun"],"active.bold":["true"]}}]}"""
+      it("should NOT expand 6 levels deep if guarded by a filter") {
+        val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.net/Individuals/M_Z","parent":"/example.net/Individuals","dataCenter":"$dcName"},"fields":{"colleagueOf.rel":["http://example.net/Individuals/I_K"]}}]}"""
         val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
         f12.map { res =>
-          Json
-            .parse(res.payload)
-            .transform(bagUuidDateEraserAndSorter)
-            .get shouldEqual expected
+          val str = new String(res.payload, "UTF-8")
+          val jsn = Json.parse(res.payload).transform(bagUuidDateEraserAndSorter)
+          withClue(s"got: $str") {
+            jsn.isSuccess should be(true)
+            jsn.get shouldEqual expected
+          }
         }
       }
 
-      it("should allow paths expansion with yg flag using full NS URI") {
+      it("should allow paths expansion with yg flag with explicit $ namespace") {
         val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/JohnSmith","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/SaraSmith"],"friendOf.rel":["http://example.org/Individuals/PeterParker"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/RonaldKhun","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/MartinOdersky"],"category.bold":["deals","news"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/HarryMiller","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/NatalieMiller"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/DonaldDuck","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"knowsByReputation.rel":["http://example.org/Individuals/MartinOdersky"],"active.bold":["true"],"mentorOf.rel":["http://example.org/Individuals/JohnSmith"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/ClarkKent","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/PeterParker","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"active.bold":["true"],"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/MartinOdersky","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/RonaldKhun"],"active.bold":["true"]}}]}"""
         val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
         f13.map { res =>
@@ -1125,7 +1147,7 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
       }
 
-      it("should allow paths expansion with yg flag with implicit namespace") {
+      it("should allow paths expansion with yg flag using full NS URI") {
         val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/JohnSmith","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/SaraSmith"],"friendOf.rel":["http://example.org/Individuals/PeterParker"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/RonaldKhun","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/MartinOdersky"],"category.bold":["deals","news"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/HarryMiller","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/NatalieMiller"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/DonaldDuck","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"knowsByReputation.rel":["http://example.org/Individuals/MartinOdersky"],"active.bold":["true"],"mentorOf.rel":["http://example.org/Individuals/JohnSmith"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/ClarkKent","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/PeterParker","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"active.bold":["true"],"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/MartinOdersky","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/RonaldKhun"],"active.bold":["true"]}}]}"""
         val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
         f14.map { res =>
@@ -1136,10 +1158,34 @@ class APIFunctionalityTests extends AsyncFunSpec
         }
       }
 
+      it("should allow paths expansion with yg flag with implicit namespace") {
+        val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/JohnSmith","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/SaraSmith"],"friendOf.rel":["http://example.org/Individuals/PeterParker"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/RonaldKhun","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/MartinOdersky"],"category.bold":["deals","news"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/HarryMiller","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"parentOf.rel":["http://example.org/Individuals/NatalieMiller"],"active.bold":["true"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/DonaldDuck","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"knowsByReputation.rel":["http://example.org/Individuals/MartinOdersky"],"active.bold":["true"],"mentorOf.rel":["http://example.org/Individuals/JohnSmith"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/ClarkKent","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/PeterParker","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"active.bold":["true"],"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"]}},{"type":"ObjectInfoton","system":{"path":"/example.org/Individuals/MartinOdersky","parent":"/example.org/Individuals","dataCenter":"$dcName"},"fields":{"collaboratesWith.rel":["http://example.org/Individuals/RonaldKhun"],"active.bold":["true"]}}]}"""
+        val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
+        f15.map { res =>
+          Json
+            .parse(res.payload)
+            .transform(bagUuidDateEraserAndSorter)
+            .get shouldEqual expected
+        }
+      }
+
+      it("should NOT allow limited paths expansion if guarded by non existed filters") {
+        val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]},"system":{"path":"/example.org/Individuals/ClarkKent","dataCenter":"$dcName","parent":"/example.org/Individuals"}},{"type":"ObjectInfoton","fields":{"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"],"active.bold":["true"]},"system":{"path":"/example.org/Individuals/PeterParker","dataCenter":"$dcName","parent":"/example.org/Individuals"}}]}"""
+        val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
+        f16.map { res =>
+          val str = new String(res.payload, "UTF-8")
+          val jsn = Json.parse(res.payload).transform(bagUuidDateEraserAndSorter)
+          withClue(s"got: $str") {
+            jsn.isSuccess should be(true)
+            jsn.get shouldEqual expected
+          }
+        }
+      }
+
       it("should allow limited paths expansion if guarded by filters") {
         val j = s"""{"type":"BagOfInfotons","infotons":[{"type":"ObjectInfoton","fields":{"neighborOf.rel":["http://example.org/Individuals/PeterParker"]},"system":{"path":"/example.org/Individuals/ClarkKent","dataCenter":"$dcName","parent":"/example.org/Individuals"}},{"type":"ObjectInfoton","fields":{"worksWith.rel":["http://example.org/Individuals/HarryMiller"],"neighborOf.rel":["http://example.org/Individuals/ClarkKent"],"active.bold":["true"]},"system":{"path":"/example.org/Individuals/PeterParker","dataCenter":"$dcName","parent":"/example.org/Individuals"}}]}"""
         val expected = Json.parse(j.getBytes("UTF-8")).transform(bagUuidDateEraserAndSorter).get
-        f15.map { res =>
+        f17.map { res =>
           val str = new String(res.payload, "UTF-8")
           val jsn = Json.parse(res.payload).transform(bagUuidDateEraserAndSorter)
           withClue(s"got: $str") {

--- a/server/cmwell-it/src/it/scala/cmwell/it/ClientsCompatabilityTests.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/ClientsCompatabilityTests.scala
@@ -39,12 +39,11 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     }
   }
 
-  val verifyResponseToAssertion: SimpleResponse[Array[Byte]] => scalatest.Assertion = { res =>
+  val verifyResponseToAssertion: SimpleResponse[String] => scalatest.Assertion = { res =>
     withClue(res) {
       res.status should be(200)
       val JsDefined(JsArray(dates)) = Json.parse(res.payload) \ "fields" \ "hasIPODateB.organization" : @unchecked
       dates.headOption.value.as[String](play.api.libs.json.Reads.StringReads) should fullyMatch regex """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z?"""
-
     }
   }
 
@@ -53,8 +52,12 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     Http.post(_in, dateWithoutTZ, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
 
-  val verifySampleFromAnna1: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna1.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3133333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna1: Future[SimpleResponse[String]] = ingestSampleFromAnna1.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3133333333",Seq("format" -> "json"))) { vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   val ingestSampleFromAnna2: Future[SimpleResponse[String]] = {
@@ -62,8 +65,12 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     Http.post(_in, dateWithoutT, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
 
-  val verifySampleFromAnna2: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna2.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3233333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna2: Future[SimpleResponse[String]] = ingestSampleFromAnna2.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3233333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   val ingestSampleFromAnna3: Future[SimpleResponse[String]] = {
@@ -71,8 +78,12 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     Http.post(_in, dateWithoutZ, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
 
-  val verifySampleFromAnna3: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna3.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3333333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna3: Future[SimpleResponse[String]] = ingestSampleFromAnna3.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3333333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   //NO MILLIS
@@ -82,8 +93,12 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     Http.post(_in, dateWithoutTZ, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
 
-  val verifySampleFromAnna4: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna4.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3433333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna4: Future[SimpleResponse[String]] = ingestSampleFromAnna4.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3433333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   val ingestSampleFromAnna5: Future[SimpleResponse[String]] = {
@@ -91,8 +106,12 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     Http.post(_in, dateWithoutT, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
 
-  val verifySampleFromAnna5: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna5.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3533333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna5: Future[SimpleResponse[String]] = ingestSampleFromAnna5.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3533333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   val ingestSampleFromAnna6: Future[SimpleResponse[String]] = {
@@ -104,13 +123,21 @@ class ClientsCompatabilityTests extends AsyncFunSpec with OptionValues with Matc
     val dateWithoutZ = raw"""<http://clients.compatability.test.permid.org/timestamp/1-3733333333> <http://permid.org/ontology/organization/hasIPODateB> "2017-04-18 11:30:00.0"^^<http://www.w3.org/2001/XMLSchema#dateTime> ."""
     Http.post(_in, dateWithoutZ, Some("text/plain;charset=UTF-8"), List("format" -> "ntriples", "force" -> ""), tokenHeader)
   }
-  val verifySampleDateSingleSecondsDigit: Future[SimpleResponse[Array[Byte]]] = ingestSampleDateSingleSecondsDigit.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3733333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleDateSingleSecondsDigit: Future[SimpleResponse[String]] = ingestSampleDateSingleSecondsDigit.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3733333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
 
-  val verifySampleFromAnna6: Future[SimpleResponse[Array[Byte]]] = ingestSampleFromAnna6.flatMap { iRes =>
-    spinCheck[Array[Byte]](1.second, true)(Http.get(path / "1-3633333333",Seq("format" -> "json")))(vRes => if (iRes.status != 400) vRes.status else iRes.status)
+  val verifySampleFromAnna6: Future[SimpleResponse[String]] = ingestSampleFromAnna6.flatMap { iRes =>
+    spinCheck[String](1.second, true)(Http.get(path / "1-3633333333",Seq("format" -> "json"))){ vRes =>
+      // making sure returned infoton won't contain internal ns identifier instead of corresponding prefix
+      val nsid = vRes.payload.contains("MA65OA")
+      if (iRes.status < 400 && !nsid) vRes.status else 503
+    }
   }
 
   describe("Clients compatability tests should") {

--- a/server/cmwell-it/src/it/scala/cmwell/it/IterationsTests.scala
+++ b/server/cmwell-it/src/it/scala/cmwell/it/IterationsTests.scala
@@ -42,7 +42,7 @@ class IterationsTests extends AsyncFunSpec with Matchers with Inspectors with He
             case _ => false
           } -> iSeq.size
         }).toOption,
-        Try(j.\("searchQueryStr").as[String]).toOption
+        Try(res.toString()).toOption //Try(j.\("searchQueryStr").as[String]).toOption
       )
     }
 

--- a/server/cmwell-util/src/main/scala/cmwell/util/cache/TimeBasedAccumulatedCache.scala
+++ b/server/cmwell-util/src/main/scala/cmwell/util/cache/TimeBasedAccumulatedCache.scala
@@ -1,0 +1,140 @@
+package cmwell.util.cache
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import ExecutionContext.{global => globalExecutionContext}
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Proj: server
+  * User: gilad
+  * Date: 2/4/18
+  * Time: 11:38 AM
+  */
+class TimeBasedAccumulatedCache[T,K,V1,V2] private(/*@volatile*/ private[this] var mainCache: Map[K,(V1,V2)],
+                                                   /*@volatile*/ private[this] var v1Cache: Map[V1,K],
+                                                   /*@volatile*/ private[this] var v2Cache: Map[V2,K],
+                                                   seedTimestamp: Long,
+                                                   coolDownMillis: Long,
+                                                   accumulateSince: Long => Future[T],
+                                                   timestampAndEntriesFromResults: T => (Long,Map[K,(V1,V2)]),
+                                                   getSingle: K => Future[(V1,V2)]) { self: LazyLogging =>
+
+  private[this] val isBeingUpdated = new AtomicBoolean(false)
+  /*@volatile*/ private[this] var timestamp: Long = seedTimestamp
+  /*@volatile*/ private[this] var checkTime: Long = System.currentTimeMillis()
+  private[this] var blacklist: Map[K,(Long,Int)] = Map.empty
+
+  @inline def getByV1(v1: V1): Option[K] = v1Cache.get(v1)
+  @inline def getByV2(v2: V2): Option[K] = v2Cache.get(v2)
+  @inline def get(key: K): Option[(V1,V2)] = mainCache.get(key).orElse(blacklist.get(key) match {
+    case Some((time,count)) if System.currentTimeMillis() - time > 1000L*count => getAnywayBlockingOnGlobal(key, math.min(30,count+1))
+    case None => getAnywayBlockingOnGlobal(key, 1)
+    case _ => None // last time we forcibly checked for `key` was less than `count` seconds ago
+  })
+
+  @inline private[this] def getAnywayBlockingOnGlobal(key: K, count: Int): Option[(V1,V2)] = {
+    val rv = Await.result(getAndUpdateSingle(key,true)(globalExecutionContext), 1.minute)
+    rv match {
+      case None => blacklist = blacklist.updated(key, System.currentTimeMillis() -> count)
+      case Some(_) => blacklist -= key
+    }
+    rv
+  }
+
+  @inline def getOrElseUpdate(key: K)(implicit ec: ExecutionContext): Future[Option[(V1,V2)]] =
+    get(key).fold(updateAndGet(key))(Future.successful[Option[(V1,V2)]] _ compose Some.apply)
+
+  private[this] def updateAndGet(key: K)(implicit ec: ExecutionContext): Future[Option[(V1,V2)]] = {
+    if(updatedRecently || !isBeingUpdated.compareAndSet(false,true)) Future.successful(mainCache.get(key))
+    else Try(accumulateSince(timestamp)).fold(Future.failed,identity).flatMap { results =>
+      val (newTimestamp, newVals) = timestampAndEntriesFromResults(results)
+
+      checkTime = System.currentTimeMillis()
+      if(newVals.isEmpty) Future.successful(mainCache.get(key))
+      else {
+        mainCache ++= newVals
+        val (v1Additions,v2Additions) = TimeBasedAccumulatedCache.getInvertedCaches(newVals)
+        v1Cache ++= v1Additions
+        v2Cache ++= v2Additions
+        timestamp = newTimestamp
+        newVals.get(key).fold[Future[Option[(V1,V2)]]] {
+          getAndUpdateSingle(key,false)
+        }(Future.successful[Option[(V1,V2)]] _ compose Some.apply)
+      }
+    }.andThen { case _ => isBeingUpdated.set(false) }
+  }
+
+  @inline private[this] def getAndUpdateSingle(key: K, shouldAcquireLock: Boolean)(implicit ec: ExecutionContext): Future[Option[(V1,V2)]] = {
+    val whenLocked = {
+      if (shouldAcquireLock) acquireLock()
+      else Future.successful(())
+    }
+    val f = whenLocked.flatMap { _ =>
+      Try(getSingle(key)).fold(Future.failed, identity).transform {
+        case Failure(_: NoSuchElementException) => Success(None)
+        case t => t map {
+          case v@(v1, v2) =>
+            mainCache += key -> v
+            v1Cache += v1 -> key
+            v2Cache += v2 -> key
+            Some(v)
+        }
+      }
+    }
+
+    if(!shouldAcquireLock) f
+    else f.andThen{ case _ => isBeingUpdated.set(false) }
+  }
+
+  def invalidate(k: K)(implicit ec: ExecutionContext): Future[Unit] = {
+    mainCache.get(k).fold(Future.successful(())) { case (v1, v2) =>
+      acquireLock().map { _ =>
+        if (mainCache.contains(k)) {
+          mainCache -= k
+          v1Cache -= v1
+          v2Cache -= v2
+        }
+        isBeingUpdated.set(false)
+      }
+    }
+  }
+
+  private[this] def updatedRecently: Boolean =
+    System.currentTimeMillis() - checkTime <= coolDownMillis
+
+  private[this] def acquireLock(maxDepth: Int = 16)(implicit ec: ExecutionContext): Future[Unit] = {
+    if(maxDepth == 0) Future.failed(new IllegalStateException(s"too many tries to acquire TimeBasedAccumulatedCache lock failed"))
+    else if(isBeingUpdated.compareAndSet(false,true)) Future.successful(())
+    else cmwell.util.concurrent.SimpleScheduler.scheduleFuture(40.millis)(acquireLock(maxDepth - 1))
+  }
+}
+
+
+object TimeBasedAccumulatedCache {
+
+
+  private def getInvertedCaches[K,V1,V2](m: Map[K,(V1,V2)]): (Map[V1,K],Map[V2,K]) = {
+    m.foldLeft(Map.empty[V1,K] -> Map.empty[V2,K]) {
+      case ((accv1,accv2),(k,(v1,v2))) =>
+        accv1.updated(v1, k) -> accv2.updated(v2, k)
+    }
+  }
+
+  def apply[T,K,V1,V2](seed: Map[K,(V1,V2)], seedTimestamp: Long, coolDown: FiniteDuration)
+                  (accumulateSince: Long => Future[T])
+                  (timestampAndEntriesFromResults: T => (Long,Map[K,(V1,V2)]))
+                  (getSingle: K => Future[(V1,V2)]): TimeBasedAccumulatedCache[T,K,V1,V2] = {
+    val (v1,v2) = getInvertedCaches(seed)
+    new TimeBasedAccumulatedCache(seed,v1,v2,
+      seedTimestamp,
+      coolDown.toMillis,
+      accumulateSince,
+      timestampAndEntriesFromResults,
+      getSingle) with LazyLogging
+  }
+}

--- a/server/cmwell-ws/app/Global.scala
+++ b/server/cmwell-ws/app/Global.scala
@@ -29,14 +29,15 @@ import com.typesafe.scalalogging.LazyLogging
 import k.grid.{Grid, GridConnection}
 import k.grid.service.ServiceTypes
 import logic.CRUDServiceFS
-import play.api.{Logger, _}
-import security.NoncesManager
+import play.api.{Logger, controllers => _}
+import security.{EagerAuthCache, NoncesManager}
 import javax.inject._
 
 import cmwell.domain.SearchResults
+import controllers.IngestPushback
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.{Failure, Success, Try}
 import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J
 
@@ -48,7 +49,7 @@ import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J
  * To change this template use File | Settings | File Templates.
  */
 @Singleton
-class Global @Inject()(crudServiceFS: CRUDServiceFS, cmwellRDFHelper: CMWellRDFHelper)(implicit ec: ExecutionContext) extends LazyLogging {
+class Global @Inject()(crudServiceFS: CRUDServiceFS, cmwellRDFHelper: CMWellRDFHelper, ingestPushback: IngestPushback, eagerAuthCache: EagerAuthCache)(implicit ec: ExecutionContext) extends LazyLogging {
 
   onStart
 
@@ -76,49 +77,43 @@ class Global @Inject()(crudServiceFS: CRUDServiceFS, cmwellRDFHelper: CMWellRDFH
 
     Subscriber.init
 
-    val recoverWithExitOnFail: PartialFunction[Throwable,Unit] = {
-      case err : Throwable => {
-        Logger.error("Failed to connect with CRUDService. Will exit now.",err)
-        sys.exit(1)
-      }
-    }
-
-    val recoverWithLogOnFail: PartialFunction[Try[SearchResults],Unit] = {
-      case Success(sr) => updateCaches(sr)
-      case Failure(ex) => logger.error("Failed to connect with CRUDService. Will exit now.",ex)
-    }
-
+//    val updateCachesOrLogAndExitOnFail: PartialFunction[Try[SearchResults],Unit] = {
+//      case Success(sr) => updateCaches(sr)
+//      case Failure(ex) =>
+//        logger.error("Failed to connect with CRUDService. Will exit now.",ex)
+//        sys.exit(1)
+//    }
+//
     RequestMonitor.init
+//
+//    Try(cmwell.util.concurrent.retry(3) {
+//        crudServiceFS.search(
+//          pathFilter = Some(PathFilter("/meta/ns", descendants = false)),
+//          fieldFilters = None,
+//          datesFilter = None,
+//          paginationParams = PaginationParams(0, initialMetaNsLoadingAmount),
+//          withHistory = false,
+//          withData = true,
+//          fieldSortParams = SortParam.empty)
+//      }.andThen(updateCachesOrLogAndExitOnFail))
+//    Logger.info("Application has started")
 
-    import scala.concurrent.duration._
-
-    scheduleAfterStart(30.seconds){
-      Try(cmwell.util.concurrent.retry(3) {
-          crudServiceFS.search(
-            pathFilter = Some(PathFilter("/meta/ns", descendants = false)),
-            fieldFilters = None,
-            datesFilter = None,
-            paginationParams = PaginationParams(0, initialMetaNsLoadingAmount),
-            withHistory = false,
-            withData = true,
-            fieldSortParams = SortParam.empty)
-        }.andThen(recoverWithLogOnFail)).recover{
-        case err: Throwable => logger.error("unexpected error occured in Global initialization",err)
-      }
+    scheduleAfterStart(2.minutes){
+      ingestPushback.sometimeAfterStart
+      eagerAuthCache.sometimeAfterStart
     }
-    Logger.info("Application has started")
   }
 
-  private def updateCaches(sr: SearchResults) = {
-
-    val groupedByUrls = sr.infotons.groupBy(_.fields.flatMap(_.get("url")))
-    val goodInfotons = groupedByUrls.collect { case (Some(k),v) if k.size==1 =>
-      val url = k.head.value.asInstanceOf[String]
-      cmwellRDFHelper.getTheFirstGeneratedMetaNsInfoton(url, v)
-    }
-
-    cmwellRDFHelper.loadNsCachesWith(goodInfotons.toSeq)
-  }
+//  private def updateCaches(sr: SearchResults) = {
+//
+//    val groupedByUrls = sr.infotons.groupBy(_.fields.flatMap(_.get("url")))
+//    val goodInfotons = groupedByUrls.collect { case (Some(k),v) if k.size==1 =>
+//      val url = k.head.value.asInstanceOf[String]
+//      cmwellRDFHelper.getTheFirstGeneratedMetaNsInfoton(url, v)
+//    }
+//
+//    cmwellRDFHelper.loadNsCachesWith(goodInfotons.toSeq)
+//  }
 
   def onStop {
     Grid.shutdown

--- a/server/cmwell-ws/app/controllers/Application.scala
+++ b/server/cmwell-ws/app/controllers/Application.scala
@@ -31,7 +31,7 @@ import cmwell.domain.{BagOfInfotons, CompoundInfoton, DeletedInfoton, FString, P
 import cmwell.formats._
 import cmwell.fts._
 import cmwell.rts.{Pull, Push, Subscriber}
-import cmwell.util.concurrent.SingleElementLazyAsyncCache
+import cmwell.util.concurrent.{SimpleScheduler, SingleElementLazyAsyncCache}
 import cmwell.util.formats.Encoders
 import cmwell.util.http.SimpleHttpClient
 import cmwell.util.loading.ScalaJsRuntimeCompiler
@@ -520,34 +520,43 @@ callback=< [URL] >
         val pathFilter = Some(PathFilter(normalizedPath, withDescendants))
         val withData = request.getQueryString("with-data")
         val fieldsFiltersFut = qpOpt.fold(Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache, cmwellRDFHelper).map(Some.apply))
-        fieldsFiltersFut.flatMap { fieldFilter =>
-
-          val formatter = request.getQueryString("format").getOrElse("json") match {
-            case FormatExtractor(formatType) =>
-              formatterManager.getFormatter(format = formatType,
-                host = request.host,
-                uri = request.uri,
-                pretty = request.queryString.keySet("pretty"),
-                callback = request.queryString.get("callback").flatMap(_.headOption),
-                fieldFilters = fieldFilter,
-                offset = Some(offset.toLong),
-                length = Some(length.toLong),
-                withData = withData)
+        fieldsFiltersFut.transformWith {
+          case Failure(err) => {
+            val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+            request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+              val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+              if(timePassedInMillis > 9000L) Future.successful(res)
+              else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+            }
           }
+          case Success(fieldFilter) => {
+            val formatter = request.getQueryString("format").getOrElse("json") match {
+              case FormatExtractor(formatType) =>
+                formatterManager.getFormatter(format = formatType,
+                  host = request.host,
+                  uri = request.uri,
+                  pretty = request.queryString.keySet("pretty"),
+                  callback = request.queryString.get("callback").flatMap(_.headOption),
+                  fieldFilters = fieldFilter,
+                  offset = Some(offset.toLong),
+                  length = Some(length.toLong),
+                  withData = withData)
+            }
 
-          val fmFut = extractFieldsMask(request,typesCache,cmwellRDFHelper)
-          crudServiceFS.startScroll(
-            pathFilter,
-            fieldFilter,
-            Some(DatesFilter(from, to)),
-            PaginationParams(offset, length),
-            scrollTtl,
-            withHistory,
-            withDeleted,
-            debugInfo = request.queryString.keySet("debug-info")).flatMap { startScrollResult =>
-            val rv = createScrollIdDispatcherActorFromIteratorId(startScrollResult.iteratorId, withHistory, (scrollTtl + 5).seconds)
-            fmFut.map { fm =>
-              Ok(formatter.render(startScrollResult.copy(iteratorId = rv).masked(fm))).as(formatter.mimetype)
+            val fmFut = extractFieldsMask(request, typesCache, cmwellRDFHelper)
+            crudServiceFS.startScroll(
+              pathFilter,
+              fieldFilter,
+              Some(DatesFilter(from, to)),
+              PaginationParams(offset, length),
+              scrollTtl,
+              withHistory,
+              withDeleted,
+              debugInfo = request.queryString.keySet("debug-info")).flatMap { startScrollResult =>
+              val rv = createScrollIdDispatcherActorFromIteratorId(startScrollResult.iteratorId, withHistory, (scrollTtl + 5).seconds)
+              fmFut.map { fm =>
+                Ok(formatter.render(startScrollResult.copy(iteratorId = rv).masked(fm))).as(formatter.mimetype)
+              }
             }
           }
         }.recover(errorHandler)
@@ -619,49 +628,58 @@ callback=< [URL] >
           case f if !Set("text", "path", "tsv", "tab", "nt", "ntriples", "nq", "nquads")(f.toLowerCase) && !f.toLowerCase.startsWith("json") => Future.successful(BadRequest(Json.obj("success" -> false, "message" -> "not a streamable type (use 'text','tsv','ntriples', 'nquads', or any json)")))
           case FormatExtractor(formatType) => {
             val fieldsFiltersFut = qpOpt.fold(Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache,cmwellRDFHelper).map(Some.apply))
-            fieldsFiltersFut.flatMap { fieldFilter =>
-              fieldsMaskFut.flatMap { fieldsMask =>
+            fieldsFiltersFut.transformWith {
+              case Failure(err) => {
+                val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+                request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+                  val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+                  if(timePassedInMillis > 9000L) Future.successful(res)
+                  else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+                }
+              } case Success(fieldFilter) => {
+                fieldsMaskFut.flatMap { fieldsMask =>
 
-                /* RDF types allowed in mstream are: ntriples, nquads, jsonld & jsonldq
+                  /* RDF types allowed in mstream are: ntriples, nquads, jsonld & jsonldq
                  * since, the jsons are not realy RDF, just flattened json of infoton per line,
                  * there is no need to tnforce subject uniquness. but ntriples, and nquads
                  * which split infoton into statements (subject-predicate-object triples) per line,
                  * we don't want different versions to "mix" and we enforce uniquness only in this case
                  */
-                val forceUniqueness: Boolean = withHistory && (formatType match {
-                  case RdfType(NquadsFlavor) => true
-                  case RdfType(NTriplesFlavor) => true
-                  case _ => false
-                })
-                val formatter = formatterManager.getFormatter(format = formatType,
-                  host = request.host,
-                  uri = request.uri,
-                  pretty = false,
-                  callback = request.queryString.get("callback").flatMap(_.headOption),
-                  fieldFilters = fieldFilter,
-                  offset = Some(offset.toLong),
-                  length = Some(500L),
-                  withData = withData,
-                  withoutMeta = !withMeta,
-                  filterOutBlanks = true,
-                  forceUniqueness = forceUniqueness) //cleanSystemBlanks set to true, so we won't output all the meta information we usaly output. it get's messy with streaming. we don't want each chunk to show the "document context"
+                  val forceUniqueness: Boolean = withHistory && (formatType match {
+                    case RdfType(NquadsFlavor) => true
+                    case RdfType(NTriplesFlavor) => true
+                    case _ => false
+                  })
+                  val formatter = formatterManager.getFormatter(format = formatType,
+                    host = request.host,
+                    uri = request.uri,
+                    pretty = false,
+                    callback = request.queryString.get("callback").flatMap(_.headOption),
+                    fieldFilters = fieldFilter,
+                    offset = Some(offset.toLong),
+                    length = Some(500L),
+                    withData = withData,
+                    withoutMeta = !withMeta,
+                    filterOutBlanks = true,
+                    forceUniqueness = forceUniqueness) //cleanSystemBlanks set to true, so we won't output all the meta information we usaly output. it get's messy with streaming. we don't want each chunk to show the "document context"
 
-                val datesFilter = {
-                  if (from.isEmpty && to.isEmpty) None
-                  else Some(DatesFilter(from, to))
-                }
-                streams.multiScrollSource(
-                  pathFilter = pathFilter,
-                  fieldFilter = fieldFilter,
-                  datesFilter = datesFilter,
-                  withHistory = withHistory,
-                  withDeleted = withDeleted).map {
-                  case (source, hits) => {
-                    val s = streams.scrollSourceToByteString(source, formatter, withData.isDefined, withHistory, length, fieldsMask)
-                    Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders("X-CM-WELL-N" -> hits.toString)
+                  val datesFilter = {
+                    if (from.isEmpty && to.isEmpty) None
+                    else Some(DatesFilter(from, to))
                   }
+                  streams.multiScrollSource(
+                    pathFilter = pathFilter,
+                    fieldFilter = fieldFilter,
+                    datesFilter = datesFilter,
+                    withHistory = withHistory,
+                    withDeleted = withDeleted).map {
+                    case (source, hits) => {
+                      val s = streams.scrollSourceToByteString(source, formatter, withData.isDefined, withHistory, length, fieldsMask)
+                      Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders("X-CM-WELL-N" -> hits.toString)
+                    }
+                  }.recover(errorHandler)
                 }.recover(errorHandler)
-              }.recover(errorHandler)
+              }
             }.recover(errorHandler)
           }
         }
@@ -705,43 +723,53 @@ callback=< [URL] >
           case f if !Set("text", "path", "tsv", "tab", "nt", "ntriples", "nq", "nquads")(f.toLowerCase) && !f.toLowerCase.startsWith("json") => Future.successful(BadRequest(Json.obj("success" -> false, "message" -> "not a streamable type (use 'text','tsv','ntriples', 'nquads', or any json)")))
           case FormatExtractor(formatType) => {
             val fieldsFiltersFut = qpOpt.fold(Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache,cmwellRDFHelper).map(Some.apply))
-            fieldsFiltersFut.flatMap { fieldFilter =>
-              fieldsMaskFut.flatMap { fieldsMask =>
-                /* RDF types allowed in mstream are: ntriples, nquads, jsonld & jsonldq
-                 * since, the jsons are not realy RDF, just flattened json of infoton per line,
-                 * there is no need to tnforce subject uniquness. but ntriples, and nquads
-                 * which split infoton into statements (subject-predicate-object triples) per line,
-                 * we don't want different versions to "mix" and we enforce uniquness only in this case
-                 */
-                val forceUniqueness: Boolean = withHistory && (formatType match {
-                  case RdfType(NquadsFlavor) => true
-                  case RdfType(NTriplesFlavor) => true
-                  case _ => false
-                })
-                val formatter = formatterManager.getFormatter(format = formatType,
-                  host = request.host,
-                  uri = request.uri,
-                  pretty = false,
-                  callback = request.queryString.get("callback").flatMap(_.headOption),
-                  fieldFilters = fieldFilter,
-                  offset = Some(offset.toLong),
-                  length = Some(500L),
-                  withData = withData,
-                  withoutMeta = !withMeta,
-                  filterOutBlanks = true,
-                  forceUniqueness = forceUniqueness) //cleanSystemBlanks set to true, so we won't output all the meta information we usaly output. it get's messy with streaming. we don't want each chunk to show the "document context"
+            fieldsFiltersFut.transformWith {
+              case Failure(err) => {
+                val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+                request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+                  val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+                  if(timePassedInMillis > 9000L) Future.successful(res)
+                  else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+                }
+              }
+              case Success(fieldFilter) => {
+                fieldsMaskFut.flatMap { fieldsMask =>
+                  /* RDF types allowed in mstream are: ntriples, nquads, jsonld & jsonldq
+               * since, the jsons are not realy RDF, just flattened json of infoton per line,
+               * there is no need to tnforce subject uniquness. but ntriples, and nquads
+               * which split infoton into statements (subject-predicate-object triples) per line,
+               * we don't want different versions to "mix" and we enforce uniquness only in this case
+               */
+                  val forceUniqueness: Boolean = withHistory && (formatType match {
+                    case RdfType(NquadsFlavor) => true
+                    case RdfType(NTriplesFlavor) => true
+                    case _ => false
+                  })
+                  val formatter = formatterManager.getFormatter(format = formatType,
+                    host = request.host,
+                    uri = request.uri,
+                    pretty = false,
+                    callback = request.queryString.get("callback").flatMap(_.headOption),
+                    fieldFilters = fieldFilter,
+                    offset = Some(offset.toLong),
+                    length = Some(500L),
+                    withData = withData,
+                    withoutMeta = !withMeta,
+                    filterOutBlanks = true,
+                    forceUniqueness = forceUniqueness) //cleanSystemBlanks set to true, so we won't output all the meta information we usaly output. it get's messy with streaming. we don't want each chunk to show the "document context"
 
-                streams.superScrollSource(
-                  pathFilter = pathFilter,
-                  fieldFilter = fieldFilter,
-                  datesFilter = Some(DatesFilter(from, to)),
-                  paginationParams = PaginationParams(offset, 500),
-                  withHistory = withHistory,
-                  withDeleted = withDeleted,
-                  parallelism = parallelism).map { case (src, hits) =>
+                  streams.superScrollSource(
+                    pathFilter = pathFilter,
+                    fieldFilter = fieldFilter,
+                    datesFilter = Some(DatesFilter(from, to)),
+                    paginationParams = PaginationParams(offset, 500),
+                    withHistory = withHistory,
+                    withDeleted = withDeleted,
+                    parallelism = parallelism).map { case (src, hits) =>
 
-                  val s = streams.scrollSourceToByteString(src, formatter, withData.isDefined, withHistory, length, fieldsMask)
-                  Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders("X-CM-WELL-N" -> hits.toString)
+                    val s = streams.scrollSourceToByteString(src, formatter, withData.isDefined, withHistory, length, fieldsMask)
+                    Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders("X-CM-WELL-N" -> hits.toString)
+                  }
                 }
               }
             }
@@ -786,68 +814,78 @@ callback=< [URL] >
           case f if !Set("text", "path", "tsv", "tab", "nt", "ntriples", "nq", "nquads")(f.toLowerCase) && !f.toLowerCase.startsWith("json") => Future.successful(BadRequest(Json.obj("success" -> false, "message" -> "not a streamable type (use any json, or one of: 'text','tsv','ntriples', or 'nquads')")))
           case FormatExtractor(formatType) => {
             val fieldsFiltersFut = qpOpt.fold(Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache,cmwellRDFHelper).map(Some.apply))
-            fieldsFiltersFut.flatMap { fieldFilter =>
-              fieldsMaskFut.flatMap { fieldsMask =>
-                /* RDF types allowed in stream are: ntriples, nquads, jsonld & jsonldq
+            fieldsFiltersFut.transformWith {
+              case Failure(err) => {
+                val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+                request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+                  val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+                  if (timePassedInMillis > 9000L) Future.successful(res)
+                  else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+                }
+              }
+              case Success(fieldFilter) => {
+                fieldsMaskFut.flatMap { fieldsMask =>
+                  /* RDF types allowed in stream are: ntriples, nquads, jsonld & jsonldq
                  * since, the jsons are not realy RDF, just flattened json of infoton per line,
                  * there is no need to tnforce subject uniquness. but ntriples, and nquads
                  * which split infoton into statements (subject-predicate-object triples) per line,
                  * we don't want different versions to "mix" and we enforce uniquness only in this case
                  */
-                val forceUniqueness: Boolean = withHistory && (formatType match {
-                  case RdfType(NquadsFlavor) => true
-                  case RdfType(NTriplesFlavor) => true
-                  case _ => false
-                })
-                val formatter = formatterManager.getFormatter(format = formatType,
-                  host = request.host,
-                  uri = request.uri,
-                  pretty = false,
-                  callback = request.queryString.get("callback").flatMap(_.headOption),
-                  fieldFilters = fieldFilter,
-                  withData = withData,
-                  withoutMeta = !withMeta,
-                  filterOutBlanks = true,
-                  forceUniqueness = forceUniqueness)
+                  val forceUniqueness: Boolean = withHistory && (formatType match {
+                    case RdfType(NquadsFlavor) => true
+                    case RdfType(NTriplesFlavor) => true
+                    case _ => false
+                  })
+                  val formatter = formatterManager.getFormatter(format = formatType,
+                    host = request.host,
+                    uri = request.uri,
+                    pretty = false,
+                    callback = request.queryString.get("callback").flatMap(_.headOption),
+                    fieldFilters = fieldFilter,
+                    withData = withData,
+                    withoutMeta = !withMeta,
+                    filterOutBlanks = true,
+                    forceUniqueness = forceUniqueness)
 
-                lazy val id = cmwell.util.numeric.Radix64.encodeUnsigned(request.id)
+                  lazy val id = cmwell.util.numeric.Radix64.encodeUnsigned(request.id)
 
-                val debugLogID = if(debugLog) Some(id) else None
+                  val debugLogID = if (debugLog) Some(id) else None
 
-                streams.scrollSource(
-                  pathFilter = pathFilter,
-                  fieldFilters = fieldFilter,
-                  datesFilter = Some(DatesFilter(from, to)),
-                  paginationParams = PaginationParams(0, 500),
-                  scrollTTL = scrollTtl,
-                  withHistory = withHistory,
-                  withDeleted = withDeleted,
-                  debugLogID = debugLogID).map { case (src, hits) =>
+                  streams.scrollSource(
+                    pathFilter = pathFilter,
+                    fieldFilters = fieldFilter,
+                    datesFilter = Some(DatesFilter(from, to)),
+                    paginationParams = PaginationParams(0, 500),
+                    scrollTTL = scrollTtl,
+                    withHistory = withHistory,
+                    withDeleted = withDeleted,
+                    debugLogID = debugLogID).map { case (src, hits) =>
 
-                  val s: Source[ByteString, NotUsed] = {
-                    val scrollSourceToByteString = streams.scrollSourceToByteString(src, formatter, withData.isDefined, withHistory, length, fieldsMask)
-                    if(debugLog) scrollSourceToByteString.via {
-                      new StreamEventInspector(
-                        onUpstreamFinishInspection =   () => logger.info(s"[$id] onUpstreamFinish"),
-                        onUpstreamFailureInspection =  error => logger.error(s"[$id] onUpstreamFailure",error),
-                        onDownstreamFinishInspection = () => logger.info(s"[$id] onDownstreamFinish"),
-                        onPullInspection =             () => logger.info(s"[$id] onPull"),
-                        onPushInspection =             bytes => {
-                          val all = bytes.utf8String
-                          val elem = {
-                            if (bytes.isEmpty) ""
-                            else all.lines.next()
-                          }
-                          logger.info(s"""[$id] onPush(first line: "$elem", num of lines: ${all.lines.size}, num of chars: ${all.length})""")
-                        })
+                    val s: Source[ByteString, NotUsed] = {
+                      val scrollSourceToByteString = streams.scrollSourceToByteString(src, formatter, withData.isDefined, withHistory, length, fieldsMask)
+                      if (debugLog) scrollSourceToByteString.via {
+                        new StreamEventInspector(
+                          onUpstreamFinishInspection = () => logger.info(s"[$id] onUpstreamFinish"),
+                          onUpstreamFailureInspection = error => logger.error(s"[$id] onUpstreamFailure", error),
+                          onDownstreamFinishInspection = () => logger.info(s"[$id] onDownstreamFinish"),
+                          onPullInspection = () => logger.info(s"[$id] onPull"),
+                          onPushInspection = bytes => {
+                            val all = bytes.utf8String
+                            val elem = {
+                              if (bytes.isEmpty) ""
+                              else all.lines.next()
+                            }
+                            logger.info(s"""[$id] onPush(first line: "$elem", num of lines: ${all.lines.size}, num of chars: ${all.length})""")
+                          })
+                      }
+                      else scrollSourceToByteString
                     }
-                    else scrollSourceToByteString
+                    val headers = {
+                      if (debugLog) List("X-CM-WELL-N" -> hits.toString, "X-CM-WELL-LOG-ID" -> id)
+                      else List("X-CM-WELL-N" -> hits.toString)
+                    }
+                    Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders(headers: _*)
                   }
-                  val headers = {
-                    if(debugLog) List("X-CM-WELL-N" -> hits.toString, "X-CM-WELL-LOG-ID" -> id)
-                    else List("X-CM-WELL-N" -> hits.toString)
-                  }
-                  Ok.chunked(s).as(overrideMimetype(formatter.mimetype, request)._2).withHeaders(headers:_*)
                 }
               }
             }
@@ -939,8 +977,16 @@ callback=< [URL] >
           withHistory = withHistory,
           withDeleted = withDeleted,
           indexTime = indexTime
-        ).map {
-          case SortedConsumeState(firstTimeStamp, path, history, deleted, descendants, fieldFilters) => {
+        ).transformWith {
+          case Failure(err) => {
+            val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+            request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+              val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+              if (timePassedInMillis > 9000L) Future.successful(res)
+              else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+            }
+          }
+          case Success(SortedConsumeState(firstTimeStamp, path, history, deleted, descendants, fieldFilters)) => {
 
             val formatter = formatterManager.getFormatter(
               format = formatType,
@@ -980,7 +1026,7 @@ callback=< [URL] >
                 overrideMimetype(formatType.mimetype, request)._2
             }
 
-            Ok.chunked(ss.batch(128,identity)(_ ++ _)).as(contentType) //TODO: `.withHeaders("X-CM-WELL-N" -> total.toString)`
+            Future.successful(Ok.chunked(ss.batch(128,identity)(_ ++ _)).as(contentType)) //TODO: `.withHeaders("X-CM-WELL-N" -> total.toString)`
           }
         }.recover(errorHandler)
       }
@@ -994,8 +1040,8 @@ callback=< [URL] >
     def apply(request: Request[Either[CMWellRequest,RawBuffer]]): Future[Result] = Try {
       request.body match {
         case Right(b) => handlePutInfoton(path)(request.map(_ => b))
-        case Left(CreateConsumer(path,qp)) => handleCreateConsumer(path)(qp)
-        case Left(Search(path,base,host,uri,qp)) => handleSearch(path,base,host,uri)(qp)
+        case Left(CreateConsumer(path,qp)) => handleCreateConsumer(path,request.attrs.get(Attrs.RequestReceivedTimestamp))(qp)
+        case Left(Search(path,base,host,uri,qp)) => handleSearch(path,base,host,uri,request.attrs.get(Attrs.RequestReceivedTimestamp))(qp)
       }
     }.recover {
       case e: Throwable => Future.successful(InternalServerError(e.getMessage + "\n" + cmwell.util.exceptions.stackTraceToString(e)))
@@ -1013,9 +1059,9 @@ callback=< [URL] >
   def handlePost(path: String) = ExtractURLFormEnc(path)
 
   private def handleCreateConsumerRequest(request: Request[AnyContent]): Future[Result] =
-    handleCreateConsumer(request.path)(request.queryString)
+    handleCreateConsumer(request.path, request.attrs.get(Attrs.RequestReceivedTimestamp))(request.queryString)
 
-  private def handleCreateConsumer(path: String)(createConsumerParams: Map[String,Seq[String]]): Future[Result] = Try {
+  private def handleCreateConsumer(path: String, requestReceivedTimestamp: Option[Long])(createConsumerParams: Map[String,Seq[String]]): Future[Result] = Try {
     val indexTime = createConsumerParams.get("index-time").flatMap(_.headOption.flatMap(asLong))
     val normalizedPath = normalizePath(path)
     val qpOpt = createConsumerParams.get("qp").flatMap(_.headOption)
@@ -1027,9 +1073,19 @@ callback=< [URL] >
       val f = generateSortedConsumeFieldFilters(qpOpt, normalizedPath, withDescendants, withHistory, withDeleted, indexTime.getOrElse(0L))
       lengthHint.fold[Future[ConsumeState]](f)(lh => f.map(_.asBulk(lh)))
     }
-    consumeStateFut.map { scs =>
-      val id = ConsumeState.encode(scs)
-      Ok("").withHeaders("X-CM-WELL-POSITION" -> id)
+    consumeStateFut.transformWith {
+      case Failure(err) => {
+        val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+        requestReceivedTimestamp.fold(Future.successful(res)) { reqStartTime =>
+          val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+          if (timePassedInMillis > 9000L) Future.successful(res)
+          else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+        }
+      }
+      case Success(scs) => {
+        val id = ConsumeState.encode(scs)
+        Future.successful(Ok("").withHeaders("X-CM-WELL-POSITION" -> id))
+      }
     }.recover(errorHandler)
   }.recover(asyncErrorHandler).get
 
@@ -1433,20 +1489,30 @@ callback=< [URL] >
         case Success(raf) =>
           val apfut = Future.traverse(raf)(RawAggregationFilter.eval(_,typesCache,cmwellRDFHelper))
           val fieldsFiltersFut = qpOpt.fold(Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache,cmwellRDFHelper).map(Some.apply))
-          fieldsFiltersFut.flatMap { fieldFilters =>
-            apfut.flatMap { af =>
-              crudServiceFS.aggregate(pathFilter, fieldFilters, Some(DatesFilter(from, to)), PaginationParams(offset, length), withHistory, af.flatten, debugInfo).map { aggResult =>
-                request.getQueryString("format").getOrElse("json") match {
-                  case FormatExtractor(formatType) => {
-                    val formatter = formatterManager.getFormatter(
-                      format = formatType,
-                      host = request.host,
-                      uri = request.uri,
-                      pretty = request.queryString.keySet("pretty"),
-                      callback = request.queryString.get("callback").flatMap(_.headOption))
-                    Ok(formatter.render(aggResult)).as(overrideMimetype(formatter.mimetype, request)._2)
+          fieldsFiltersFut.transformWith {
+            case Failure(err) => {
+              val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+              request.attrs.get(Attrs.RequestReceivedTimestamp).fold(Future.successful(res)) { reqStartTime =>
+                val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+                if (timePassedInMillis > 9000L) Future.successful(res)
+                else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+              }
+            }
+            case Success(fieldFilters) => {
+              apfut.flatMap { af =>
+                crudServiceFS.aggregate(pathFilter, fieldFilters, Some(DatesFilter(from, to)), PaginationParams(offset, length), withHistory, af.flatten, debugInfo).map { aggResult =>
+                  request.getQueryString("format").getOrElse("json") match {
+                    case FormatExtractor(formatType) => {
+                      val formatter = formatterManager.getFormatter(
+                        format = formatType,
+                        host = request.host,
+                        uri = request.uri,
+                        pretty = request.queryString.keySet("pretty"),
+                        callback = request.queryString.get("callback").flatMap(_.headOption))
+                      Ok(formatter.render(aggResult)).as(overrideMimetype(formatter.mimetype, request)._2)
+                    }
+                    case unrecognized: String => BadRequest(s"unrecognized format requested: $unrecognized")
                   }
-                  case unrecognized: String => BadRequest(s"unrecognized format requested: $unrecognized")
                 }
               }
             }
@@ -1464,12 +1530,13 @@ callback=< [URL] >
   }
 
   private def handleSearch(r: Request[AnyContent]): Future[Result] =
-    handleSearch(normalizePath(r.path),cmWellBase(r),r.host,r.uri)(r.queryString)
+    handleSearch(normalizePath(r.path),cmWellBase(r),r.host,r.uri, r.attrs.get(Attrs.RequestReceivedTimestamp))(r.queryString)
 
   private def handleSearch(normalizedPath: String,
                            cmWellBase: String,
                            requestHost: String,
-                           requestUri: String)(implicit queryString: Map[String,Seq[String]]): Future[Result] =
+                           requestUri: String,
+                           requestReceivedTimestamp: Option[Long])(implicit queryString: Map[String,Seq[String]]): Future[Result] =
     getQueryString("qp")
       .fold(Success(None): Try[Option[RawFieldFilter]])(FieldFilterParser.parseQueryParams(_).map(Some.apply))
       .map { qpOpt =>
@@ -1503,8 +1570,16 @@ callback=< [URL] >
         else {
           val fieldSortParamsFut = RawSortParam.eval(rawSortParams,crudServiceFS,typesCache,cmwellRDFHelper)
           val fieldsFiltersFut = qpOpt.fold[Future[Option[FieldFilter]]](Future.successful(Option.empty[FieldFilter]))(rff => RawFieldFilter.eval(rff,typesCache,cmwellRDFHelper).map(Some.apply))
-          fieldsFiltersFut.flatMap { fieldFilters =>
-            fieldSortParamsFut.flatMap { fieldSortParams =>
+          fieldsFiltersFut.transformWith {
+            case Failure(err) => {
+              val res = FailedDependency(Json.obj("success" -> false, "message" -> s"failed to evaluate given qp [${qpOpt.fold("")(_.toString)}]"))
+              requestReceivedTimestamp.fold(Future.successful(res)) { reqStartTime =>
+                val timePassedInMillis = System.currentTimeMillis() - reqStartTime
+                if (timePassedInMillis > 9000L) Future.successful(res)
+                else SimpleScheduler.schedule((9500L - timePassedInMillis).millis)(res)
+              }
+            }
+            case Success(fieldFilters) => fieldSortParamsFut.flatMap { fieldSortParams =>
               crudServiceFS.search(pathFilter, fieldFilters, Some(DatesFilter(from, to)),
                 PaginationParams(offset, length), withHistory, withData, fieldSortParams, debugInfo, withDeleted).flatMap { unmodifiedSearchResult =>
 

--- a/server/cmwell-ws/app/filters/GeneralAttributesFilter.scala
+++ b/server/cmwell-ws/app/filters/GeneralAttributesFilter.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class GeneralAttributesFilter @Inject()(implicit val mat: Materializer, ec: ExecutionContext) extends Filter with TypeHelpers {
   override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader) = {
     f(rh.addAttr(Attrs.RequestReceivedTimestamp, System.currentTimeMillis())
-      .addAttr(Attrs.UserIP, rh.headers.get("X-Forwarded-For").getOrElse(rh.remoteAddress)) // TODO: might be good to add ip to logs when user misbehaves
+        .addAttr(Attrs.UserIP, rh.headers.get("X-Forwarded-For").getOrElse(rh.remoteAddress)) // TODO: might be good to add ip to logs when user misbehaves
     )
   }
 }

--- a/server/cmwell-ws/app/ld/util/LDFormatParser.scala
+++ b/server/cmwell-ws/app/ld/util/LDFormatParser.scala
@@ -768,7 +768,10 @@ object LDFormatParser extends LazyLogging {
         case Some(fName) => (predicateUrl, fName)
       }
 
-      if (url.endsWith("/meta/nn#")) Some(firstName)
+      if (url.endsWith("/meta/nn#")) {
+        if(firstName.contains(".")) throw new IllegalArgumentException(s"nn (No Namespace) fields aren't allowed to contain dots. [$url$firstName]")
+        else Some(firstName)
+      }
       else cmwellRDFHelper.urlToHash(url).map{
         hash =>  s"$firstName.$hash"
       }

--- a/server/cmwell-ws/app/wsutil/package.scala
+++ b/server/cmwell-ws/app/wsutil/package.scala
@@ -386,7 +386,8 @@ package object wsutil extends LazyLogging {
     override def resolve(cmwellRDFHelper: CMWellRDFHelper)(implicit ec: ExecutionContext) = cmwellRDFHelper.urlToHashAsync(nsUri)
   }
   case class PrefixPattern(prefix: String) extends ResolvedNsPattern {
-    override def resolve(cmwellRDFHelper: CMWellRDFHelper)(implicit ec: ExecutionContext) = cmwellRDFHelper.getUrlAndLastForPrefixAsync(prefix).map(_._2)
+    override def resolve(cmwellRDFHelper: CMWellRDFHelper)(implicit ec: ExecutionContext) =
+      cmwellRDFHelper.getIdentifierForPrefixAsync(prefix)
   }
 
   case object JokerPattern                       extends FieldPattern


### PR DESCRIPTION
- /meta writes will now be ingested to priority queue prior to regular writes
- validating ns infotons before caching
- adjusted tests
- added a time based accumulating caching solution
- nn fields ingested to _in will refuse to accept dots in field name from now on
- auxilary caches are derived directly from main structure
- (potentialy) malicious `qp` queries will be returned with 424 error code and with delay completing request time to 9.5 seconds, giving that requested completed in under 9 seconds.