### PR TITLE
Bumping Scala to 2.12.6

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -20,7 +20,7 @@ sys.env.get("BUILD_NUMBER") match {
   )
 }
 
-scalaVersion in Global := "2.12.5"
+scalaVersion in Global := "2.12.6"
 //javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 initialize := {
   import semverfi._

--- a/server/project/build.sbt
+++ b/server/project/build.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++=  Seq(
 
 val s = Seq(
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
-  scalaVersion := "2.12.5"
+  scalaVersion := "2.12.6"
 )
 
 sourceGenerators in Compile += Def.task {


### PR DESCRIPTION
Updating as 2.12.5 had issues with macros when compiling on Java 9 or 10.