### PR TITLE
properly save all the offsets in indexer and not just the max one

### DIFF
--- a/server/cmwell-bg/src/main/scala/cmwell/bg/IndexerStream.scala
+++ b/server/cmwell-bg/src/main/scala/cmwell/bg/IndexerStream.scala
@@ -391,7 +391,6 @@ class IndexerStream(partition: Int,
                         else ir.esAction.toString
                     }}"
                   )
-                  val highestOffset = bgMessages.map(_.offsets).flatten.max
                   indexBulkSizeHist += esIndexRequests.size
                   indexingTimer
                     .timeFuture(
@@ -400,12 +399,7 @@ class IndexerStream(partition: Int,
                       )
                     )
                     .map { bulkIndexResult =>
-                      BGMessage(
-                        highestOffset,
-                        (bulkIndexResult, bgMessages.map {
-                          _.message._2
-                        })
-                      )
+                        BGMessage(bgMessages.flatMap(_.offsets), (bulkIndexResult, bgMessages.map(_.message._2)))
                     }
               }
             )


### PR DESCRIPTION
It solves a bug that in case of a mixed priority and non priority writes there will be no proper offset updats.