### PR TITLE
proper fallback to QUORUM

### DIFF
--- a/server/cmwell-irw/src/main/scala/cmwell/irw/IRWServiceNativeImpl2.scala
+++ b/server/cmwell-irw/src/main/scala/cmwell/irw/IRWServiceNativeImpl2.scala
@@ -217,7 +217,7 @@ class IRWServiceNativeImpl2(
   ): Future[Box[Infoton]] = {
 
     def getFromCas(lvl: ConsistencyLevel, isARetry: Boolean = false): Future[Box[Infoton]] = {
-      val stmt = getInfotonUUID.bind(uuid).setConsistencyLevel(level)
+      val stmt = getInfotonUUID.bind(uuid).setConsistencyLevel(lvl)
       val resultedInfotonFuture =
         cmwell.util.concurrent.retry(5, delayOnError, 2)(executeAsyncInternal(stmt).map(convert(uuid)))(ec)
       resultedInfotonFuture


### PR DESCRIPTION
properly fallback to quorum in case reading with consistency level of one returns empty result