### PR TITLE
Resolves 429 Too Many Requests

### DIFF
--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/internal-consistency.sh
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/internal-consistency.sh
@@ -49,6 +49,7 @@ rm -rf "${WORKING_DIRECTORY}"/infoton-data-integrity
 # Extract key fields from index, path and infoton.
 # For the index, we do additional analysis, so extract all system fields.
 # We want all of the retrieval operations to be grouped together do minimize the inconsistency window.
+# Disable source filtering because of Elastic index bug returning random 500 internal server errors.
 
 extract_start=`date +%s`
 
@@ -58,6 +59,7 @@ ${JAVA_HOME}/bin/java \
  -cp "${EXTRACT_ES_UUIDS_JAR}" cmwell.analytics.main.DumpSystemFieldsFromEs \
  --out "${WORKING_DIRECTORY}/${EXTRACT_DIRECTORY_INDEX}" \
  --format parquet \
+ --no-source-filter \
  "${CMWELL_INSTANCE}"
 
 ${SPARK_HOME}/bin/spark-submit \

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/internal-consistency.sh
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/scripts/internal-consistency.sh
@@ -3,13 +3,30 @@
 # Run a suite of internal data consistency checks on a CM-Well instance.
 
 if [ -z $1 ]; then
- echo "usage: $0 <cmwell-url>"
+ echo "usage: $0 <cmwell-url> [--no-source-filter]"
  exit 1
 fi
 
-source ./set-runtime.sh
-
 CMWELL_INSTANCE=$1
+
+export SOURCE_FILTER="--source-filter"
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "usage: $0 <cmwell-url> [--no-source-filter]"
+            exit 1
+            ;;
+        -nsf|--no-source-filter)
+            shift
+            export SOURCE_FILTER="--no-source-filter"
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+source ./set-runtime.sh
 
 # Do all our work in this directory
 WORKING_DIRECTORY="internal-consistency"
@@ -58,8 +75,8 @@ ${JAVA_HOME}/bin/java \
  -XX:+UseG1GC \
  -cp "${EXTRACT_ES_UUIDS_JAR}" cmwell.analytics.main.DumpSystemFieldsFromEs \
  --out "${WORKING_DIRECTORY}/${EXTRACT_DIRECTORY_INDEX}" \
+ "${SOURCE_FILTER}" \
  --format parquet \
- --no-source-filter \
  "${CMWELL_INSTANCE}"
 
 ${SPARK_HOME}/bin/spark-submit \

--- a/tools/dataConsistencyTool/cmwell-spark-analysis/src/test/scala/cmwell/analytics/util/TestDiscoverEsTopology.scala
+++ b/tools/dataConsistencyTool/cmwell-spark-analysis/src/test/scala/cmwell/analytics/util/TestDiscoverEsTopology.scala
@@ -2,17 +2,22 @@ package cmwell.analytics.util
 
 import org.scalatest.{FlatSpec, Ignore, Matchers}
 
-@Ignore // Requires a CM-Well instance to be running locally.
+// Requires a CM-Well instance to be running locally.
 class TestDiscoverEsTopology extends FlatSpec with Matchers {
 
-  val hostPort = "localhost:9201"
-  val esTopology = DiscoverEsTopology(hostPort, "cm_well_all")
+  "Topology" should "find nodes and shards" ignore {
 
-  esTopology.nodes should not be empty
-  esTopology.shards should not be empty
+    val hostPort = "localhost:9201"
+    val esTopology = DiscoverEsTopology(hostPort, "cm_well_all")
 
-  for {
-    (_, nodeIds) <- esTopology.shards
-    nodeId <- nodeIds
-  } esTopology.nodes.keys should contain(nodeId)
+    esTopology.nodes should not be empty
+    esTopology.shards should not be empty
+
+    for {
+      (_, nodeIds) <- esTopology.shards
+      nodeId <- nodeIds
+    } esTopology.nodes.keys should contain(nodeId)
+  
+  }
+
 }

--- a/tools/dataConsistencyTool/extract-index-from-es/src/main/resources/application.conf
+++ b/tools/dataConsistencyTool/extract-index-from-es/src/main/resources/application.conf
@@ -43,7 +43,7 @@ extract-index-from-es {
   csv-write-chunk-size = 1000000
 
   # The maximum number of attempts to read data before giving up.
-  max-read-attempts = 20
+  max-read-attempts = 40
 
   # These estimates of the returned document size should be accurate for all CM-Well instances
   # since filtering is applied to the document fields returned.

--- a/tools/dataConsistencyTool/extract-index-from-es/src/scripts/dump-system-fields-from-es.sh
+++ b/tools/dataConsistencyTool/extract-index-from-es/src/scripts/dump-system-fields-from-es.sh
@@ -4,13 +4,30 @@
 # The resulting file will contain the columns: kind, uuid, lastModified, path, dc, indexName, parent, current.
 
 if [ -z $1 ]; then
- echo "usage: $0 <cmwell-url>"
+ echo "usage: $0 <cmwell-url> [--no-source-filter]"
  exit 1
 fi
 
-source  ./set-runtime.sh
-
 CMWELL_INSTANCE=$1
+
+export SOURCE_FILTER="--source-filter"
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "usage: $0 <cmwell-url> [--no-source-filter]"
+            exit 1
+            ;;
+        -nsf|--no-source-filter)
+            shift
+            export SOURCE_FILTER="--no-source-filter"
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+source  ./set-runtime.sh
 
 WORKING_DIRECTORY="dump-index-from-es"
 EXTRACT_ES_UUIDS_JAR="extract-index-from-es-assembly-0.1.jar"
@@ -24,7 +41,7 @@ $JAVA_HOME/bin/java \
  -XX:+UseG1GC \
  -cp "${EXTRACT_ES_UUIDS_JAR}" cmwell.analytics.main.DumpSystemFieldsFromEs \
  --out "${WORKING_DIRECTORY}/es-system-fields" \
- --no-source-filter \
+ "${SOURCE_FILTER}" \
  --format parquet \
  "${CMWELL_INSTANCE}"
 

--- a/tools/dataConsistencyTool/extract-index-from-es/src/scripts/dump-system-fields-from-es.sh
+++ b/tools/dataConsistencyTool/extract-index-from-es/src/scripts/dump-system-fields-from-es.sh
@@ -24,5 +24,10 @@ $JAVA_HOME/bin/java \
  -XX:+UseG1GC \
  -cp "${EXTRACT_ES_UUIDS_JAR}" cmwell.analytics.main.DumpSystemFieldsFromEs \
  --out "${WORKING_DIRECTORY}/es-system-fields" \
+ --no-source-filter \
  --format parquet \
  "${CMWELL_INSTANCE}"
+
+# Touch the _SUCCESS file to indicate successful completion
+touch "${WORKING_DIRECTORY}/es-system-fields/_SUCCESS"
+


### PR DESCRIPTION
Disables source filtering in `dump-system-fields-from-es.sh` to address issue (500 internal server error) with source-filter-included queries against troubled Elastic indexes. Increases `max-read-attempts` to allow more retries of failed shard downloads. Modifies `PartitionedDownlaoader` to specify more information in logs and to pause between download request retries when a request fails. Modifies `TestDiscoverEsTopology`, labeling the test intent and ignoring that intent as the test was not being ignored locally with `@Ignore`.