### PR TITLE
Set number of shards

### DIFF
--- a/server/cmwell-cons/src/main/scala/ComponentConf.scala
+++ b/server/cmwell-cons/src/main/scala/ComponentConf.scala
@@ -411,7 +411,7 @@ case class ElasticsearchConf(clusterName: String,
 
     val confContent = ResourceBuilder.getResource(s"scripts/templates/${template}", m)
 
-    val m2 = Map[String, String]("number_of_shards" -> expectedNodes.toString,
+    val m2 = Map[String, String]("number_of_shards" -> Math.min(expectedNodes, 10).toString,
                                  "number_of_replicas" -> numberOfReplicas.toString)
     val mappingContent = ResourceBuilder.getResource(s"scripts/templates/mapping.json", m2)
     val mappingContentNew = ResourceBuilder.getResource(s"scripts/templates/indices_template_new.json", m2)


### PR DESCRIPTION
resolve #850 

The requirement is to set a number of shards only on new installations while in upgrade process we should not change it.
1. On a fresh install -> number of shards is equal to Min(#nodes, 10)
2. On upgrade with Elastic restart -> number of shards was not changed
3. On upgrade without Elastic restart -> number of shards was not changed

Scenarios 1-3 were tested on both PE and cluster