### PR TITLE
Support versioning in build.sbt

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -28,9 +28,9 @@ def refreshVersion = Command.command("refreshVersion") { state =>
 
 ThisBuild / commands += refreshVersion
 
-val dirtyEnd = """.*(-\d\d\d\d)$""".r
+val dirtyEnd = """.*(\d\d\d\d\d\d\d\d)(-\d\d\d\d)$""".r
 def stripTime(version: String) = version match {
-  case dirtyEnd(time) => version.stripSuffix(time)
+  case dirtyEnd(date, time) => version.replace("+"+date, "-"+date).stripSuffix(time)
   case _ => version
 }
 ThisBuild / version ~= stripTime
@@ -174,6 +174,7 @@ dependenciesManager in Global := {
   case ("xerces","xercesImpl")                                     => "xerces" % "xercesImpl" % "2.12.0"
   case ("xml-apis","xml-apis")                                     => "xml-apis" % "xml-apis" % "1.4.01"
   case ("uk.org.lidalia","sysout-over-slf4j")                      => "uk.org.lidalia" % "sysout-over-slf4j" % "1.0.2"
+  case ("net.leibman", "semverfi")                                 => "net.leibman" %% "semverfi" % "0.2.0"
 }
 
 //dependencyOverrides in Global ++= {

--- a/server/cmwell-cons/build.sbt
+++ b/server/cmwell-cons/build.sbt
@@ -8,6 +8,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process._
 import cmwell.build.{Versions,CMWellBuild}
 
+libraryDependencies ++= {
+  val dm = dependenciesManager.value
+  Seq(
+      dm("net.leibman", "semverfi"))
+}
+
 name := "cmwell-cons"
 
 unmanagedResources := Seq()
@@ -266,7 +272,7 @@ getLib := {
   packProject("dc",(pack in LocalProject("dc") in pack).value,bd, bd / "app" / "conf" / "dc",logger)
   packProject("ws",(pack in LocalProject("ws") in pack).value,bd, bd / "app" / "conf" / "ws",logger)
   packProject("bg",(pack in LocalProject("bg") in pack).value,bd, bd / "app" / "conf" / "bg",logger)
-  packCons((pack in LocalProject("ctrl") in pack).value, getCons.value , bd)
+  packCons((pack in LocalProject("cons") in pack).value, getCons.value , bd)
 
   lib
 }


### PR DESCRIPTION
Fix include 3 parts: 
1. packCons will refer to *cons* and not to controller so that semverfi will be included
2. before date we will have - and not + for versioning correctness
3. Adding dependency for semverfi
